### PR TITLE
ApiResponse 추가

### DIFF
--- a/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
+++ b/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
@@ -4,6 +4,7 @@ import com.jandi.band_backend.club.dto.ClubReqDTO;
 import com.jandi.band_backend.club.dto.ClubRespDTO;
 import com.jandi.band_backend.club.dto.PageRespDTO;
 import com.jandi.band_backend.club.service.ClubService;
+import com.jandi.band_backend.global.ApiResponse;
 import com.jandi.band_backend.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -28,12 +29,13 @@ public class ClubController {
      * universityId가 null이면 연합 동아리로, 값이 있으면 특정 대학 소속 동아리로 생성됩니다.
      */
     @PostMapping
-    public ResponseEntity<ClubRespDTO.Response> createClub(
+    public ResponseEntity<ApiResponse<ClubRespDTO.Response>> createClub(
             @Valid @RequestBody ClubReqDTO.Request request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Integer userId = userDetails.getUserId();
         ClubRespDTO.Response response = clubService.createClub(request, userId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "동아리가 성공적으로 생성되었습니다", response));
     }
 
     /**
@@ -42,10 +44,10 @@ public class ClubController {
      * 응답에는 각 동아리가 연합 동아리인지 여부(isUnionClub)와 소속 대학(있는 경우)이 포함됩니다.
      */
     @GetMapping
-    public ResponseEntity<PageRespDTO<ClubRespDTO.SimpleResponse>> getClubList(
+    public ResponseEntity<ApiResponse<PageRespDTO<ClubRespDTO.SimpleResponse>>> getClubList(
             @PageableDefault(size = 5) Pageable pageable) {
         PageRespDTO<ClubRespDTO.SimpleResponse> response = clubService.getClubList(pageable);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리 목록 조회 성공", response));
     }
 
     /**
@@ -54,10 +56,10 @@ public class ClubController {
      * 연합 동아리인 경우 university 필드는 null이고 isUnionClub은 true입니다.
      */
     @GetMapping("/{clubId}")
-    public ResponseEntity<ClubRespDTO.Response> getClubDetail(
+    public ResponseEntity<ApiResponse<ClubRespDTO.Response>> getClubDetail(
             @PathVariable Integer clubId) {
         ClubRespDTO.Response response = clubService.getClubDetail(clubId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리 상세 정보 조회 성공", response));
     }
 
     /**
@@ -66,13 +68,13 @@ public class ClubController {
      * universityId를 변경하여 소속 대학을 변경하거나, null로 설정하여 연합 동아리로 변경할 수 있습니다.
      */
     @PatchMapping("/{clubId}")
-    public ResponseEntity<ClubRespDTO.Response> updateClub(
+    public ResponseEntity<ApiResponse<ClubRespDTO.Response>> updateClub(
             @PathVariable Integer clubId,
             @Valid @RequestBody ClubReqDTO.UpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Integer userId = userDetails.getUserId();
         ClubRespDTO.Response response = clubService.updateClub(clubId, request, userId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리 정보가 성공적으로 수정되었습니다", response));
     }
 
     /**
@@ -80,11 +82,11 @@ public class ClubController {
      * 대표자가 동아리를 삭제합니다.
      */
     @DeleteMapping("/{clubId}")
-    public ResponseEntity<Void> deleteClub(
+    public ResponseEntity<ApiResponse<Void>> deleteClub(
             @PathVariable Integer clubId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Integer userId = userDetails.getUserId();
         clubService.deleteClub(clubId, userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리가 성공적으로 삭제되었습니다"));
     }
 }

--- a/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
+++ b/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
@@ -35,7 +35,7 @@ public class ClubController {
         Integer userId = userDetails.getUserId();
         ClubRespDTO.Response response = clubService.createClub(request, userId);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(HttpStatus.CREATED, "동아리가 성공적으로 생성되었습니다", response));
+                .body(ApiResponse.success("동아리가 성공적으로 생성되었습니다", response));
     }
 
     /**
@@ -47,7 +47,7 @@ public class ClubController {
     public ResponseEntity<ApiResponse<PageRespDTO<ClubRespDTO.SimpleResponse>>> getClubList(
             @PageableDefault(size = 5) Pageable pageable) {
         PageRespDTO<ClubRespDTO.SimpleResponse> response = clubService.getClubList(pageable);
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리 목록 조회 성공", response));
+        return ResponseEntity.ok(ApiResponse.success("동아리 목록 조회 성공", response));
     }
 
     /**
@@ -59,7 +59,7 @@ public class ClubController {
     public ResponseEntity<ApiResponse<ClubRespDTO.Response>> getClubDetail(
             @PathVariable Integer clubId) {
         ClubRespDTO.Response response = clubService.getClubDetail(clubId);
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리 상세 정보 조회 성공", response));
+        return ResponseEntity.ok(ApiResponse.success("동아리 상세 정보 조회 성공", response));
     }
 
     /**
@@ -74,7 +74,7 @@ public class ClubController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Integer userId = userDetails.getUserId();
         ClubRespDTO.Response response = clubService.updateClub(clubId, request, userId);
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리 정보가 성공적으로 수정되었습니다", response));
+        return ResponseEntity.ok(ApiResponse.success("동아리 정보가 성공적으로 수정되었습니다", response));
     }
 
     /**
@@ -87,6 +87,6 @@ public class ClubController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Integer userId = userDetails.getUserId();
         clubService.deleteClub(clubId, userId);
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "동아리가 성공적으로 삭제되었습니다"));
+        return ResponseEntity.ok(ApiResponse.success("동아리가 성공적으로 삭제되었습니다"));
     }
 }

--- a/src/main/java/com/jandi/band_backend/global/ApiResponse.java
+++ b/src/main/java/com/jandi/band_backend/global/ApiResponse.java
@@ -1,0 +1,68 @@
+package com.jandi.band_backend.global;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값인 아래의 최상위 필드는 JSON 응답에 포함하지 않음
+public class ApiResponse<T> {
+
+    private final int status;        // HTTP 상태 코드 값 (예: 200, 404, 500)
+    private final boolean success;   // 성공 여부
+    private final String message;    // 응답 메시지
+    private final T data;            // 실제 응답 데이터 (성공 시)
+    private final String errorCode;  // 커스텀 에러 코드 (실패 시)
+
+    // 성공 시 생성자 (데이터 포함)
+    private ApiResponse(HttpStatus httpStatus, String message, T data) {
+        this.status = httpStatus.value();
+        this.success = true;
+        this.message = message;
+        this.data = data;
+        this.errorCode = null;
+    }
+
+    // 성공 시 생성자 (데이터 미포함, 메시지만)
+    private ApiResponse(HttpStatus httpStatus, String message) {
+        this.status = httpStatus.value();
+        this.success = true;
+        this.message = message;
+        this.data = null;
+        this.errorCode = null;
+    }
+
+    // 실패 시 생성자
+    private ApiResponse(HttpStatus httpStatus, String message, String errorCode) {
+        this.status = httpStatus.value();
+        this.success = false;
+        this.message = message;
+        this.data = null;
+        this.errorCode = errorCode;
+    }
+
+    // 성공 응답 (데이터 + 커스텀 메시지)
+    public static <T> ApiResponse<T> success(HttpStatus httpStatus, String message, T data) {
+        return new ApiResponse<>(httpStatus, message, data);
+    }
+
+    // 성공 응답 (데이터만, HttpStatus 기본 메시지 사용)
+    public static <T> ApiResponse<T> success(HttpStatus httpStatus, T data) {
+        return new ApiResponse<>(httpStatus, httpStatus.getReasonPhrase(), data);
+    }
+
+    // 성공 응답 (데이터 없이 커스텀 메시지만, 예: 생성 성공 후 별도 데이터 반환 없을 때)
+    public static <T> ApiResponse<T> success(HttpStatus httpStatus, String message) {
+        return new ApiResponse<>(httpStatus, message);
+    }
+
+    // 실패 응답 (커스텀 메시지 + 에러 코드)
+    public static <T> ApiResponse<T> error(HttpStatus httpStatus, String message, String errorCode) {
+        return new ApiResponse<>(httpStatus, message, errorCode);
+    }
+
+    // 실패 응답 (커스텀 메시지만, HttpStatus 이름을 에러 코드로 사용)
+    public static <T> ApiResponse<T> error(HttpStatus httpStatus, String message) {
+        return new ApiResponse<>(httpStatus, message, httpStatus.name());
+    }
+}

--- a/src/main/java/com/jandi/band_backend/global/ApiResponse.java
+++ b/src/main/java/com/jandi/band_backend/global/ApiResponse.java
@@ -2,21 +2,18 @@ package com.jandi.band_backend.global;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL) // null 값인 아래의 최상위 필드는 JSON 응답에 포함하지 않음
 public class ApiResponse<T> {
 
-    private final int status;        // HTTP 상태 코드 값 (예: 200, 404, 500)
     private final boolean success;   // 성공 여부
     private final String message;    // 응답 메시지
     private final T data;            // 실제 응답 데이터 (성공 시)
     private final String errorCode;  // 커스텀 에러 코드 (실패 시)
 
     // 성공 시 생성자 (데이터 포함)
-    private ApiResponse(HttpStatus httpStatus, String message, T data) {
-        this.status = httpStatus.value();
+    private ApiResponse(String message, T data) {
         this.success = true;
         this.message = message;
         this.data = data;
@@ -24,8 +21,7 @@ public class ApiResponse<T> {
     }
 
     // 성공 시 생성자 (데이터 미포함, 메시지만)
-    private ApiResponse(HttpStatus httpStatus, String message) {
-        this.status = httpStatus.value();
+    private ApiResponse(String message) {
         this.success = true;
         this.message = message;
         this.data = null;
@@ -33,8 +29,7 @@ public class ApiResponse<T> {
     }
 
     // 실패 시 생성자
-    private ApiResponse(HttpStatus httpStatus, String message, String errorCode) {
-        this.status = httpStatus.value();
+    private ApiResponse(String message, String errorCode) {
         this.success = false;
         this.message = message;
         this.data = null;
@@ -42,27 +37,17 @@ public class ApiResponse<T> {
     }
 
     // 성공 응답 (데이터 + 커스텀 메시지)
-    public static <T> ApiResponse<T> success(HttpStatus httpStatus, String message, T data) {
-        return new ApiResponse<>(httpStatus, message, data);
-    }
-
-    // 성공 응답 (데이터만, HttpStatus 기본 메시지 사용)
-    public static <T> ApiResponse<T> success(HttpStatus httpStatus, T data) {
-        return new ApiResponse<>(httpStatus, httpStatus.getReasonPhrase(), data);
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(message, data);
     }
 
     // 성공 응답 (데이터 없이 커스텀 메시지만, 예: 생성 성공 후 별도 데이터 반환 없을 때)
-    public static <T> ApiResponse<T> success(HttpStatus httpStatus, String message) {
-        return new ApiResponse<>(httpStatus, message);
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(message);
     }
 
     // 실패 응답 (커스텀 메시지 + 에러 코드)
-    public static <T> ApiResponse<T> error(HttpStatus httpStatus, String message, String errorCode) {
-        return new ApiResponse<>(httpStatus, message, errorCode);
-    }
-
-    // 실패 응답 (커스텀 메시지만, HttpStatus 이름을 에러 코드로 사용)
-    public static <T> ApiResponse<T> error(HttpStatus httpStatus, String message) {
-        return new ApiResponse<>(httpStatus, message, httpStatus.name());
+    public static <T> ApiResponse<T> error(String message, String errorCode) {
+        return new ApiResponse<>(message, errorCode);
     }
 }


### PR DESCRIPTION
## 작업 내용
- RESTful API의 표준화된 응답 패턴을 구현한 `ApiResponse를 global 디렉토리에 작성함.
- 1차 스프린트 때 작성한 코드를 맞추어 변경하면서 예시로 올림. 

> 이 표준화된 API 응답 구조는 프론트엔드 개발자가 응답을 일관되게 처리할 수 있도록 하고, 에러 처리와 성공 응답을 명확하게 구분할 수 있게 해줍니다. 특히 `success` 플래그를 통해 직관적인 상태 파악이 가능하며, 적절한 HTTP 상태 코드와 메시지를 함께 제공하여 디버깅과 개발 효율성을 높여줍니다.

## JSON 응답 예시 (수정됨)

### 1. 사용자 목록 조회 성공 (200 OK)
```json
{
  "success": true,
  "message": "사용자 목록 조회 성공",
  "data": [
    {
      "id": 1,
      "name": "홍길동",
      "email": "hong@example.com",
      "createdAt": "2023-11-10T14:30:22"
    },
    {
      "id": 2,
      "name": "김철수",
      "email": "kim@example.com",
      "createdAt": "2023-11-09T09:45:12"
    }
  ]
}
```

### 2. 단일 사용자 조회 성공 (200 OK)
```json
{
  "success": true,
  "message": "사용자 조회 성공",
  "data": {
    "id": 1,
    "name": "홍길동",
    "email": "hong@example.com",
    "createdAt": "2023-11-10T14:30:22"
  }
}
```

### 3. 사용자 조회 실패 (404 Not Found)
```json
{
  "success": false,
  "message": "사용자를 찾을 수 없습니다.",
  "errorCode": "USER_NOT_FOUND"
}
```

### 4. 사용자 생성 성공 (201 Created)
```json
{
  "success": true,
  "message": "사용자 생성 성공",
  "data": {
    "id": 3,
    "name": "박지민",
    "email": "park@example.com",
    "createdAt": "2023-11-15T10:20:33"
  }
}
```

### 5. 사용자 삭제 성공 (200 OK)
```json
{
  "success": true,
  "message": "사용자 삭제 성공"
}
```