### PR TITLE
유저 정보 조회 및 수정 API 작업

### DIFF
--- a/src/main/java/com/jandi/band_backend/user/controller/UserController.java
+++ b/src/main/java/com/jandi/band_backend/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.jandi.band_backend.user.controller;
+
+import com.jandi.band_backend.global.ApiResponse;
+import com.jandi.band_backend.security.jwt.JwtTokenProvider;
+import com.jandi.band_backend.user.dto.UserInfoDTO;
+import com.jandi.band_backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping("/me/info")
+    public ApiResponse<UserInfoDTO> getMyInfo(
+            @RequestHeader("Authorization") String token
+    ) {
+        String accessToken = token.replace("Bearer ", "");
+        String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
+        UserInfoDTO userInfo = userService.getMyInfo(kakaoOauthId);
+        return ApiResponse.success("내 정보 조회 성공", userInfo);
+    }
+}

--- a/src/main/java/com/jandi/band_backend/user/controller/UserController.java
+++ b/src/main/java/com/jandi/band_backend/user/controller/UserController.java
@@ -2,19 +2,20 @@ package com.jandi.band_backend.user.controller;
 
 import com.jandi.band_backend.global.ApiResponse;
 import com.jandi.band_backend.security.jwt.JwtTokenProvider;
+import com.jandi.band_backend.user.dto.UpdateUserInfoReqDTO;
 import com.jandi.band_backend.user.dto.UserInfoDTO;
+import com.jandi.band_backend.user.service.UserPhotoService;
 import com.jandi.band_backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final UserPhotoService userPhotoService;
     private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/me/info")
@@ -23,7 +24,28 @@ public class UserController {
     ) {
         String accessToken = token.replace("Bearer ", "");
         String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
-        UserInfoDTO userInfo = userService.getMyInfo(kakaoOauthId);
+
+        // 유저 기본 정보 및 프로필 정보 조회
+        UserInfoDTO userInfo = new UserInfoDTO(
+                userService.getMyInfo(kakaoOauthId),
+                userPhotoService.getMyPhoto(kakaoOauthId)
+        );
         return ApiResponse.success("내 정보 조회 성공", userInfo);
+    }
+
+    @PatchMapping("/me/info")
+    public ApiResponse<UserInfoDTO> updateMyInfo(
+            @RequestHeader("Authorization") String token,
+            @ModelAttribute UpdateUserInfoReqDTO updateDTO,
+            @RequestPart(value = "profilePhoto", required = false) MultipartFile profilePhoto
+
+    ) {
+        String accessToken = token.replace("Bearer ", "");
+        String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
+
+        // 유저 기본 정보 및 프로필 사진 수정
+        userService.updateMyInfo(kakaoOauthId, updateDTO);
+        userPhotoService.updateMyPhoto(kakaoOauthId, profilePhoto);
+        return ApiResponse.success("내 정보 수정 성공");
     }
 }

--- a/src/main/java/com/jandi/band_backend/user/dto/UpdateUserInfoReqDTO.java
+++ b/src/main/java/com/jandi/band_backend/user/dto/UpdateUserInfoReqDTO.java
@@ -1,0 +1,14 @@
+package com.jandi.band_backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateUserInfoReqDTO {
+    private String nickname;
+    private String position;
+    private String university;
+}

--- a/src/main/java/com/jandi/band_backend/user/dto/UserInfoDTO.java
+++ b/src/main/java/com/jandi/band_backend/user/dto/UserInfoDTO.java
@@ -8,7 +8,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class UserInfoDTO {
-    private int id;
+    private Integer id; // 자체 고유 아이디 (카카오 회원번호 아님)
     private String nickname;
     private String profilePhoto;
     private String position;

--- a/src/main/java/com/jandi/band_backend/user/entity/Users.java
+++ b/src/main/java/com/jandi/band_backend/user/entity/Users.java
@@ -26,6 +26,7 @@ import lombok.Setter;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Table(name = "users")
@@ -138,7 +139,15 @@ public class Users {
     }
     
     public enum Position {
-        VOCAL, GUITAR, KEYBOARD, BASS, DRUM, OTHER
+        VOCAL, GUITAR, KEYBOARD, BASS, DRUM, OTHER;
+
+        public static Position from(String name) {
+            try {
+                return Position.valueOf(name);
+            } catch (Exception e) {
+                return null;
+            }
+        }
     }
     
     public enum AdminRole {

--- a/src/main/java/com/jandi/band_backend/user/repository/UserPhotoRepository.java
+++ b/src/main/java/com/jandi/band_backend/user/repository/UserPhotoRepository.java
@@ -4,6 +4,8 @@ import com.jandi.band_backend.user.entity.UserPhoto;
 import com.jandi.band_backend.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPhotoRepository extends JpaRepository<UserPhoto, Long> {
     UserPhoto findByUser(Users user);
 }

--- a/src/main/java/com/jandi/band_backend/user/service/UserPhotoService.java
+++ b/src/main/java/com/jandi/band_backend/user/service/UserPhotoService.java
@@ -1,0 +1,70 @@
+package com.jandi.band_backend.user.service;
+
+import com.jandi.band_backend.global.exception.UserNotFoundException;
+import com.jandi.band_backend.image.service.S3Service;
+import com.jandi.band_backend.user.entity.UserPhoto;
+import com.jandi.band_backend.user.entity.Users;
+import com.jandi.band_backend.user.repository.UserPhotoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserPhotoService {
+    private final S3Service s3Service;
+    private final UserService userService;
+    private final UserPhotoRepository userPhotoRepository;
+
+    private final String kakaoPrefix = "k.kakaocdn.net";
+    private final String s3DirName = "user-photo";
+
+    /// 유저 프로필 사진 조회
+    public UserPhoto getMyPhoto(String kakaoOauthId) {
+        Users user = userService.getMyInfo(kakaoOauthId);
+        UserPhoto userProfile = userPhotoRepository.findByUser(user);
+
+        if (userProfile == null) throw new UserNotFoundException();
+        return userProfile;
+    }
+
+    /// 유저 프로필 사진 수정
+    public void updateMyPhoto(String kakaoOauthId, MultipartFile newProfileFile) {
+        // 프로필 사진이 없을 경우 수정하지 않음
+        if (newProfileFile == null || newProfileFile.isEmpty()) return;
+
+        // 프로필 조회
+        UserPhoto profile = getMyPhoto(kakaoOauthId);
+        String originalUrl = profile.getImageUrl();
+
+        // 새 이미지 업로드 및 이전 이미지 삭제
+        String newUrl = uploadNewProfileFile(newProfileFile);
+        deleteOriginalProfileFile(originalUrl);
+        profile.setImageUrl(newUrl);
+        userPhotoRepository.save(profile);
+    }
+
+    /// 내부 메서드
+    // S3에 새 프로필 이미지 업로드
+    private String uploadNewProfileFile(MultipartFile newProfileFile) {
+        try{
+            return s3Service.uploadImage(newProfileFile, s3DirName);
+        }catch (Exception e) {
+            throw new RuntimeException("프로필 사진 업로드 실패: " + e.getMessage());
+        }
+    }
+
+    // S3에서 이전 프로필 이미지 삭제
+    private void deleteOriginalProfileFile(String originalProfileUrl) {
+        // 카카오 기본 프로필인 경우 삭제 작업을 잔행하지 않음
+        if(originalProfileUrl.contains(kakaoPrefix)) return;
+
+        try{
+            s3Service.deleteImage(originalProfileUrl);
+        }catch (Exception e) {
+            log.error("프로필 사진 삭제 실패: url={}", originalProfileUrl);
+        }
+    }
+}

--- a/src/main/java/com/jandi/band_backend/user/service/UserService.java
+++ b/src/main/java/com/jandi/band_backend/user/service/UserService.java
@@ -1,10 +1,10 @@
 package com.jandi.band_backend.user.service;
 
 import com.jandi.band_backend.global.exception.UserNotFoundException;
-import com.jandi.band_backend.user.dto.UserInfoDTO;
-import com.jandi.band_backend.user.entity.UserPhoto;
+import com.jandi.band_backend.univ.entity.University;
+import com.jandi.band_backend.univ.repository.UniversityRepository;
+import com.jandi.band_backend.user.dto.UpdateUserInfoReqDTO;
 import com.jandi.band_backend.user.entity.Users;
-import com.jandi.band_backend.user.repository.UserPhotoRepository;
 import com.jandi.band_backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,15 +13,31 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
-    private final UserPhotoRepository userPhotoRepository;
+    private final UniversityRepository universityRepository;
 
-    /// 내 정보 조회
-    public UserInfoDTO getMyInfo(String kakaoOauthId) {
-        // 유저 및 유저 프로필 조회
-        Users user = userRepository.findByKakaoOauthId(kakaoOauthId)
+    /// 내 기본 정보 조회
+    public Users getMyInfo(String kakaoOauthId) {
+        return userRepository.findByKakaoOauthId(kakaoOauthId)
                 .orElseThrow(UserNotFoundException::new);
-        UserPhoto userProfile = userPhotoRepository.findByUser(user);
+    }
 
-        return new UserInfoDTO(user, userProfile);
+    /// 내 기본 정보 수정
+    public void updateMyInfo(String kakaoOauthId, UpdateUserInfoReqDTO updateDTO) {
+        Users user = getMyInfo(kakaoOauthId);
+        updateUser(user, updateDTO);
+    }
+
+    /// 내부 메서드
+    // 유저 정보 수정
+    private void updateUser(Users user, UpdateUserInfoReqDTO updateDTO) {
+        String newNickName = updateDTO.getNickname();
+        University newUniversity = universityRepository.findByName(updateDTO.getUniversity());
+        Users.Position newPosition = Users.Position.from(updateDTO.getPosition());
+
+        // 있는 정보만 수정, 없다면 오류는 내지 않되 반영하지 않음
+        if (newNickName != null && !newNickName.isEmpty()) user.setNickname(newNickName);
+        if (newUniversity != null) user.setUniversity(newUniversity);
+        if (newPosition != null) user.setPosition(newPosition);
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #BACK_BB_006
- Closes #BACK_BB_007

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 유저 정보 조회 API 작업
- 유저 정보 수정 API 작업

## **✅ 변경 사항**

- 유저 기본정보(닉네임, 포지션, 대학)과 유저 프로필 사진을 서비스 분리하여 각각 'UserService', 'UserPhotoService'로 작업했음
- S3관련하여 aplication.properties 수정 필요 << 디스코드에 적어놓겠습니다

## **📸 스크린샷 (선택)**
<img width="736" alt="image" src="https://github.com/user-attachments/assets/de0aa1b2-1ee2-4185-85e6-eebdf9927f18" />
<img width="735" alt="image" src="https://github.com/user-attachments/assets/f8b78d35-2e14-46a1-a62b-99576a7942a4" />


## **💬 코멘트**
- 내 정보 수정 성공 시 메세지 이외에 별도 데이터를 전해주고 있지 않은데, 수정된 UserInfoDTO를 데이터로 넘겨주어야 할까요?
