### PR TITLE
FIX: 팀 일정에서 제외 포지션 enum 수정

### DIFF
--- a/src/main/java/com/jandi/band_backend/team/entity/TeamEvent.java
+++ b/src/main/java/com/jandi/band_backend/team/entity/TeamEvent.java
@@ -16,66 +16,66 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class TeamEvent {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "team_event_id")
     private Integer id;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
-    
+
     @Column(name = "name", nullable = false, length = 255)
     private String name;
-    
+
     @Column(name = "start_datetime", nullable = false)
     private Instant startDatetime;
-    
+
     @Column(name = "end_datetime", nullable = false)
     private Instant endDatetime;
-    
+
     @Column(name = "location", length = 255)
     private String location;
-    
+
     @Column(name = "address", length = 255)
     private String address;
-    
+
     @Enumerated(EnumType.STRING)
     @Column(name = "no_position")
     private NoPosition noPosition = NoPosition.NONE;
-    
+
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_user_id", nullable = false)
     private Users creator;
-    
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
-    
+
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
-    
+
     @Column(name = "deleted_at")
     private Instant deletedAt;
-    
+
     @OneToMany(mappedBy = "teamEvent")
     private List<TeamEventParticipant> participants = new ArrayList<>();
-    
+
     @PrePersist
     protected void onCreate() {
         createdAt = Instant.now();
         updatedAt = Instant.now();
     }
-    
+
     @PreUpdate
     protected void onUpdate() {
         updatedAt = Instant.now();
     }
-    
+
     public enum NoPosition {
-        VOCAL, GUITAR, DRUM, NONE
+        VOCAL, GUITAR, KEYBOARD, BASS, DRUM, NONE
     }
-} 
+}


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 승휘님의 일정 포지션 제외와 동기화함
- Mysql 변경사항 반영함
```
ALTER TABLE team_event 
MODIFY COLUMN no_position ENUM('VOCAL', 'GUITAR', 'KEYBOARD', 'BASS', 'DRUM', 'NONE');
```