### PR TITLE
로그인/회원가입 시 기존 유저의 요청은 제한하도록 변경

### DIFF
--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.jandi.band_backend.auth.controller;
 
-import com.jandi.band_backend.auth.dto.AuthRespDTO;
+import com.jandi.band_backend.auth.dto.TokenRespDTO;
 import com.jandi.band_backend.auth.dto.RefreshReqDTO;
 import com.jandi.band_backend.auth.dto.SignUpReqDTO;
 import com.jandi.band_backend.global.ApiResponse;
@@ -18,10 +18,10 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/login")
-    public ApiResponse<AuthRespDTO> kakaoLogin(
+    public ApiResponse<TokenRespDTO> kakaoLogin(
             @RequestParam String code
     ){
-        AuthRespDTO tokens = authService.login(code);
+        TokenRespDTO tokens = authService.login(code);
         return ApiResponse.success("로그인 성공", tokens);
     }
 
@@ -37,11 +37,11 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ApiResponse<AuthRespDTO> refresh(
+    public ApiResponse<TokenRespDTO> refresh(
             @RequestBody RefreshReqDTO refreshReqDTO
     ){
         String refreshToken = refreshReqDTO.getRefreshToken();
-        AuthRespDTO tokens = authService.refresh(refreshToken);
+        TokenRespDTO tokens = authService.refresh(refreshToken);
         return ApiResponse.success("토큰 재발급 성공", tokens);
     }
 }

--- a/src/main/java/com/jandi/band_backend/auth/dto/LoginRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/auth/dto/LoginRespDTO.java
@@ -1,0 +1,13 @@
+package com.jandi.band_backend.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRespDTO extends TokenRespDTO{
+    private final Boolean isRegistered;
+
+    public LoginRespDTO(String accessToken, String refreshToken, Boolean isRegistered) {
+        super(accessToken, refreshToken);
+        this.isRegistered = isRegistered;
+    }
+}

--- a/src/main/java/com/jandi/band_backend/auth/dto/TokenRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/auth/dto/TokenRespDTO.java
@@ -2,10 +2,12 @@ package com.jandi.band_backend.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
-public class AuthRespDTO {
+public class TokenRespDTO {
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.jandi.band_backend.auth.dto.kakao.KakaoTokenRespDTO;
 import com.jandi.band_backend.auth.dto.kakao.KakaoUserInfoDTO;
 import com.jandi.band_backend.auth.service.kakao.KaKaoTokenService;
 import com.jandi.band_backend.auth.service.kakao.KakaoUserService;
+import com.jandi.band_backend.global.exception.InvalidAccessException;
 import com.jandi.band_backend.global.exception.InvalidTokenException;
 import com.jandi.band_backend.global.exception.UserNotFoundException;
 import com.jandi.band_backend.security.jwt.JwtTokenProvider;
@@ -32,7 +33,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     /// 로그인
-    public AuthRespDTO login(String code){
+    public TokenRespDTO login(String code){
         // 카카오로부터 유저 정보 얻기
         KakaoTokenRespDTO kakaoToken = kaKaoTokenService.getKakaoToken(code);
         KakaoUserInfoDTO kakaoUserInfo = kakaoUserService.getKakaoUserInfo(kakaoToken.getAccessToken());
@@ -40,10 +41,16 @@ public class AuthService {
         // DB에서 유저를 찾되, 없다면 임시 회원 가입 진행
         Users user = getOrCreateUser(kakaoUserInfo);
 
+        // 만약 탈퇴 회원이라면 로그인 불가
+        if(user.getDeletedAt() != null) { // 탈퇴 회원이라면 로그인 불가
+            throw new InvalidAccessException("탈퇴 후 7일간 서비스 이용이 불가합니다.");
+        }
+
         // 자체 jwt 토큰 발급
-        return new AuthRespDTO(
+        return new LoginRespDTO(
             jwtTokenProvider.generateAccessToken(user.getKakaoOauthId()),
-            jwtTokenProvider.generateRefreshToken(user.getKakaoOauthId())
+            jwtTokenProvider.generateRefreshToken(user.getKakaoOauthId()),
+            user.getIsRegistered()
         );
     }
 
@@ -54,15 +61,21 @@ public class AuthService {
         Users user = userRepository.findByKakaoOauthId(kakaoOauthId)
                 .orElseThrow(UserNotFoundException::new);
 
+        // 회원가입 여부 확인 -> 정식 회원가입 완료한 기존 회원이라면 진행하지 않음
+        if(user.getIsRegistered()) {
+            throw new InvalidAccessException("이미 회원 가입이 완료된 계정입니다");
+        }
+
         // 기본 유저 정보 입력
         University university = universityRepository.findByName(reqDTO.getUniversity());
         Users.Position position = Users.Position.valueOf(reqDTO.getPosition());
 
         user.setUniversity(university);
         user.setPosition(position);
+        user.setIsRegistered(true);
         userRepository.save(user);
 
-        log.info("KakaoOauthId: {}에 대해 임시 회원 가입 완료", kakaoOauthId);
+        log.info("KakaoOauthId: {}에 대해 정식 회원 가입 완료", kakaoOauthId);
 
         // 유저 정보 반환: 유저 기본 정보, 유저 프로필
         return new UserInfoDTO(
@@ -71,7 +84,7 @@ public class AuthService {
     }
 
     /// 리프레시 토큰 생성
-    public AuthRespDTO refresh(String refreshToken) {
+    public TokenRespDTO refresh(String refreshToken) {
         // 리프레시 토큰 검증
         if(!jwtTokenProvider.validateToken(refreshToken)) {
             throw new InvalidTokenException();
@@ -79,7 +92,7 @@ public class AuthService {
 
         // 토큰 재발급
         String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(refreshToken);
-        return new AuthRespDTO(
+        return new TokenRespDTO(
                 jwtTokenProvider.generateAccessToken(kakaoOauthId),
                 jwtTokenProvider.generateRefreshToken(kakaoOauthId)
         );

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -18,6 +18,7 @@ import com.jandi.band_backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -47,6 +48,7 @@ public class AuthService {
     }
 
     /// 정식 회원가입
+    @Transactional
     public UserInfoDTO signup(String kakaoOauthId, SignUpReqDTO reqDTO) {
         // 유저 조회
         Users user = userRepository.findByKakaoOauthId(kakaoOauthId)
@@ -84,8 +86,9 @@ public class AuthService {
     }
 
     /// 내부 메서드
-    // DB에서 유저를 찾되, 없다면 임시 회원 가입 진행
-    private Users getOrCreateUser(KakaoUserInfoDTO kakaoUserInfo) {
+    // DB에서 유저를 찾되, 없다면 임시 회원 가입 진행. 만약 가입시 문제가 생기면 롤백
+    @Transactional
+    public Users getOrCreateUser(KakaoUserInfoDTO kakaoUserInfo) {
         String kakaoOauthId = kakaoUserInfo.getKakaoOauthId();
         return userRepository.findByKakaoOauthId(kakaoOauthId)
                 .orElseGet(() -> createTemporaryUser(kakaoUserInfo));

--- a/src/main/java/com/jandi/band_backend/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/jandi/band_backend/global/GlobalExceptionHandler.java
@@ -1,16 +1,13 @@
 package com.jandi.band_backend.global;
 
-import com.jandi.band_backend.global.exception.FailKakaoReadUserException;
-import com.jandi.band_backend.global.exception.InvalidTokenException;
-import com.jandi.band_backend.global.exception.FailKakaoLoginException;
-import com.jandi.band_backend.global.exception.UserNotFoundException;
+import com.jandi.band_backend.global.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
-    /// 일반적인 예외
+    /// 일반적인 예외 처리
     // 전역적 런타임 에러
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponse<?>> handleRuntimeException(RuntimeException ex) {
@@ -35,13 +32,21 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ex.getMessage(), "USER_NOT_FOUND"));
     }
 
-    /// 토큰 예외 처리
+    /// 부적절 예외 처리
     // 부적절한 토큰
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ApiResponse<?>> handleInvalidToken(InvalidTokenException ex) {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.error(ex.getMessage(), "INVALID_TOKEN"));
+    }
+
+    // 잘못된 접근
+    @ExceptionHandler(InvalidAccessException.class)
+    public ResponseEntity<ApiResponse<?>> handleInvalidAccess(InvalidAccessException ex) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error(ex.getMessage(), "INVALID_ACCESS"));
     }
 
     /// 카카오 예외 처리

--- a/src/main/java/com/jandi/band_backend/global/exception/InvalidAccessException.java
+++ b/src/main/java/com/jandi/band_backend/global/exception/InvalidAccessException.java
@@ -1,0 +1,8 @@
+package com.jandi.band_backend.global.exception;
+
+// 잘못된 접근, 권한없는 접근 등
+public class InvalidAccessException extends RuntimeException {
+    public InvalidAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jandi/band_backend/user/entity/Users.java
+++ b/src/main/java/com/jandi/band_backend/user/entity/Users.java
@@ -56,7 +56,10 @@ public class Users {
     @Enumerated(EnumType.STRING)
     @Column(name = "admin_role", nullable = false)
     private AdminRole adminRole = AdminRole.USER;
-    
+
+    @Column(name = "is_registered", nullable = false)
+    private Boolean isRegistered = Boolean.FALSE;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
     
@@ -122,7 +125,7 @@ public class Users {
     
     @OneToMany(mappedBy = "reporter")
     private List<PromoCommentReport> promoCommentReports = new ArrayList<>();
-    
+
     @PrePersist
     protected void onCreate() {
         position = null;
@@ -136,7 +139,7 @@ public class Users {
     protected void onUpdate() {
         updatedAt = Instant.now();
     }
-    
+
     public enum Position {
         VOCAL, GUITAR, KEYBOARD, BASS, DRUM, OTHER
     }


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**
- 로그인 시 탈퇴된 회원은 토큰발급되지 않도록 함
- 회원가입 시 기존 회원은 재가입되지 않도록 함
- 로그인 시 기존/신규 회원을 구분할 수 있게 토큰과 함께 isRegistered를 함께 넘겨주도록 변경함

## **✅ 변경 사항**

- 소프트 딜리트 시 실제 삭제는 7일 후에 이루어진다고 보고, 일단 deletedAt에 값이 있으면 탈퇴한 유저로 간주하여 토큰을 발급하지 않고 InvalidAccessException을 던지게 했습니다.
- 정식 회원 가입 시 isRegistered 여부를 확인하여 true라면 기존 회원으로 간주하여 회원가입을 막고 InvalidAccessException를 던지게 했습니다.
- 이를 위해 커스텀 예외 InvalidAccessException를 만들었으며, GlobalExceptionHandler에도 이 커스텀 예외를 추가하였습니다.
- DB에 회원가입 완료 여부를 저장하는 isRegistered를 추가했습니다.
- 로그인 응답시 isRegistered가 추가됨에 따라 토큰 재발급 응답이 달라져서, 기존의 AuthRespDTO의 이름을 TokenRespDTO로 수정하고, 이를 상속받는 LoginRespDTO를 추가했습니다.

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- API 명세서, DTO 명세서에 미리 선반영 해두었습니다!
