### PR TITLE
FEAT: 투표 행사 관련 기능 추가

### DIFF
--- a/src/main/java/com/jandi/band_backend/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/jandi/band_backend/global/GlobalExceptionHandler.java
@@ -65,6 +65,22 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ex.getMessage(), "POLL_SONG_NOT_FOUND"));
     }
 
+    // 행사한 해당 투표 미존재
+    @ExceptionHandler(VoteNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleVoteNotFound(VoteNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(ex.getMessage(), "VOTE_NOT_FOUND"));
+    }
+
+    // 행사한 해당 투표 이미 존재
+    @ExceptionHandler(VoteAlreadyExistsException.class)
+    public ResponseEntity<ApiResponse<?>> handleVoteAlreadyExists(VoteAlreadyExistsException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT) // 409 Conflict - 리소스 충돌
+                .body(ApiResponse.error(ex.getMessage(), "VOTE_ALREADY_EXISTS"));
+    }
+
     // 동아리 접근 권한 없음
     @ExceptionHandler(UnauthorizedClubAccessException.class)
     public ResponseEntity<ApiResponse<?>> handleUnauthorizedClubAccess(UnauthorizedClubAccessException ex) {

--- a/src/main/java/com/jandi/band_backend/global/exception/UserNotFoundException.java
+++ b/src/main/java/com/jandi/band_backend/global/exception/UserNotFoundException.java
@@ -4,4 +4,8 @@ public class UserNotFoundException extends RuntimeException {
     public UserNotFoundException() {
         super("존재하지 않는 사용자입니다");
     }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/jandi/band_backend/global/exception/VoteAlreadyExistsException.java
+++ b/src/main/java/com/jandi/band_backend/global/exception/VoteAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.jandi.band_backend.global.exception;
+
+public class VoteAlreadyExistsException extends RuntimeException {
+    public VoteAlreadyExistsException() {
+        super("이미 해당 노래에 대한 같은 투표가 존재합니다.");
+    }
+
+    public VoteAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jandi/band_backend/global/exception/VoteNotFoundException.java
+++ b/src/main/java/com/jandi/band_backend/global/exception/VoteNotFoundException.java
@@ -1,0 +1,11 @@
+package com.jandi.band_backend.global.exception;
+
+public class VoteNotFoundException extends RuntimeException {
+    public VoteNotFoundException() {
+        super("해당 투표를 찾을 수 없습니다.");
+    }
+
+    public VoteNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -40,8 +40,11 @@ public class PollController {
     }
 
     @GetMapping("/{pollId}")
-    public ResponseEntity<ApiResponse<PollDetailRespDTO>> getPollDetail(@PathVariable Integer pollId) {
-        PollDetailRespDTO responseDto = pollService.getPollDetail(pollId);
+    public ResponseEntity<ApiResponse<PollDetailRespDTO>> getPollDetail(
+            @PathVariable Integer pollId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Integer currentUserId = userDetails != null ? userDetails.getUserId() : null;
+        PollDetailRespDTO responseDto = pollService.getPollDetail(pollId, currentUserId);
         return ResponseEntity.ok(ApiResponse.success("투표 상세 정보를 조회했습니다.", responseDto));
     }
 

--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -54,4 +54,24 @@ public class PollController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("곡이 성공적으로 투표에 추가되었습니다.", responseDto));
     }
+
+    @PutMapping("/{pollId}/songs/{songId}/votes/{emoji}")
+    public ResponseEntity<ApiResponse<PollSongRespDTO>> setVoteForSong(
+            @PathVariable Integer pollId,
+            @PathVariable Integer songId,
+            @PathVariable String emoji,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PollSongRespDTO responseDto = pollService.setVoteForSong(pollId, songId, emoji, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("투표가 설정되었습니다.", responseDto));
+    }
+
+    @DeleteMapping("/{pollId}/songs/{songId}/votes/{emoji}")
+    public ResponseEntity<ApiResponse<PollSongRespDTO>> removeVoteFromSong(
+            @PathVariable Integer pollId,
+            @PathVariable Integer songId,
+            @PathVariable String emoji,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PollSongRespDTO responseDto = pollService.removeVoteFromSong(pollId, songId, emoji, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("투표가 취소되었습니다.", responseDto));
+    }
 }

--- a/src/main/java/com/jandi/band_backend/poll/dto/PollSongRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/poll/dto/PollSongRespDTO.java
@@ -25,4 +25,5 @@ public class PollSongRespDTO {
     private Integer dislikeCount;
     private Integer cantCount;
     private Integer hajjCount;
+    private String userVoteType;
 }

--- a/src/main/java/com/jandi/band_backend/poll/entity/Vote.java
+++ b/src/main/java/com/jandi/band_backend/poll/entity/Vote.java
@@ -32,7 +32,7 @@ public class Vote {
     @Column(name = "voted_mark", nullable = false)
     private VotedMark votedMark;
     
-    @Column(name = "voted_at", nullable = false, updatable = false)
+    @Column(name = "voted_at", nullable = false)
     private LocalDateTime votedAt;
     
     @PrePersist
@@ -40,7 +40,12 @@ public class Vote {
         votedAt = LocalDateTime.now();
     }
     
+    @PreUpdate
+    protected void onUpdate() {
+        votedAt = LocalDateTime.now();
+    }
+
     public enum VotedMark {
         LIKE, DISLIKE, CANT, HAJJ
     }
-} 
+}

--- a/src/main/java/com/jandi/band_backend/poll/repository/VoteRepository.java
+++ b/src/main/java/com/jandi/band_backend/poll/repository/VoteRepository.java
@@ -1,0 +1,15 @@
+package com.jandi.band_backend.poll.repository;
+
+import com.jandi.band_backend.poll.entity.Vote;
+import com.jandi.band_backend.poll.entity.Vote.VotedMark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface VoteRepository extends JpaRepository<Vote, Integer> {
+    Optional<Vote> findByPollSongIdAndUserIdAndVotedMark(Integer pollSongId, Integer userId, VotedMark votedMark);
+    List<Vote> findByPollSongIdAndUserId(Integer pollSongId, Integer userId);
+}

--- a/src/main/java/com/jandi/band_backend/poll/service/PollService.java
+++ b/src/main/java/com/jandi/band_backend/poll/service/PollService.java
@@ -2,14 +2,15 @@ package com.jandi.band_backend.poll.service;
 
 import com.jandi.band_backend.club.entity.Club;
 import com.jandi.band_backend.club.repository.ClubRepository;
-import com.jandi.band_backend.global.exception.ClubNotFoundException;
-import com.jandi.band_backend.global.exception.PollNotFoundException;
-import com.jandi.band_backend.global.exception.UserNotFoundException;
+import com.jandi.band_backend.global.exception.*;
 import com.jandi.band_backend.poll.dto.*;
 import com.jandi.band_backend.poll.entity.Poll;
 import com.jandi.band_backend.poll.entity.PollSong;
+import com.jandi.band_backend.poll.entity.Vote;
+import com.jandi.band_backend.poll.entity.Vote.VotedMark;
 import com.jandi.band_backend.poll.repository.PollRepository;
 import com.jandi.band_backend.poll.repository.PollSongRepository;
+import com.jandi.band_backend.poll.repository.VoteRepository;
 import com.jandi.band_backend.user.entity.Users;
 import com.jandi.band_backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class PollService {
     private final PollSongRepository pollSongRepository;
     private final ClubRepository clubRepository;
     private final UserRepository userRepository;
+    private final VoteRepository voteRepository;
 
     @Transactional
     public PollRespDTO createPoll(PollCreateReqDTO requestDto, Integer currentUserId) {
@@ -45,8 +47,8 @@ public class PollService {
         Poll poll = new Poll();
         poll.setClub(club);
         poll.setTitle(requestDto.getTitle());
-        poll.setStartDatetime(LocalDateTime.now()); // 현재 시간 저장
-        poll.setEndDatetime(requestDto.getEndDatetime()); // 클라이언트에서 전달한 시간 저장
+        poll.setStartDatetime(LocalDateTime.now());
+        poll.setEndDatetime(requestDto.getEndDatetime());
         poll.setCreator(creator);
 
         Poll savedPoll = pollRepository.save(poll);
@@ -107,16 +109,120 @@ public class PollService {
         return convertToPollSongRespDTO(savedPollSong);
     }
 
+    @Transactional
+    public PollSongRespDTO setVoteForSong(Integer pollId, Integer songId, String voteType, Integer currentUserId) {
+        // 사용자 조회
+        Users user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new UserNotFoundException());
+
+        // 노래 조회
+        PollSong pollSong = pollSongRepository.findById(songId)
+                .orElseThrow(() -> new PollSongNotFoundException("해당 노래를 찾을 수 없습니다."));
+
+        // 투표 조회 (pollId 확인)
+        if (!pollSong.getPoll().getId().equals(pollId)) {
+            throw new PollSongNotFoundException("해당 투표에 속한 노래가 아닙니다.");
+        }
+
+        // 투표 타입 변환
+        VotedMark votedMark = convertToVotedMark(voteType);
+
+        // 사용자가 이 곡에 대한 투표를 했는지 확인 (타입 상관없이)
+        List<Vote> userVotesForSong = voteRepository.findByPollSongIdAndUserId(songId, currentUserId);
+
+        // 같은 타입의 투표가 있는지 확인
+        boolean hasSameTypeVote = userVotesForSong.stream()
+                .anyMatch(v -> v.getVotedMark() == votedMark);
+
+        // 이미 같은 타입 투표가 있으면 예외 발생
+        if (hasSameTypeVote) {
+            throw new VoteAlreadyExistsException(
+                "이미 이 노래에 대한 '" + voteType + "' 투표가 존재합니다. " +
+                "취소하려면 DELETE 요청을 사용하세요."
+            );
+        }
+
+        // 다른 타입의 투표가 있으면 기존 투표의 타입을 업데이트
+        if (!userVotesForSong.isEmpty()) {
+            // 첫 번째 투표 가져오기 (한 곡에 최대 한 개의 투표만 가능)
+            Vote existingVote = userVotesForSong.getFirst();
+            existingVote.setVotedMark(votedMark);
+            // 추가 투표가 있으면 삭제 (혹시 모를 중복 투표 제거)
+            if (userVotesForSong.size() > 1) {
+                for (int i = 1; i < userVotesForSong.size(); i++) {
+                    voteRepository.delete(userVotesForSong.get(i));
+                }
+            }
+        }
+        // 투표가 없으면 새로 생성
+        else {
+            Vote vote = new Vote();
+            vote.setPollSong(pollSong);
+            vote.setUser(user);
+            vote.setVotedMark(votedMark);
+            voteRepository.save(vote);
+        }
+
+        // 업데이트된 노래 정보 반환
+        return convertToPollSongRespDTO(pollSong);
+    }
+
+    @Transactional
+    public PollSongRespDTO removeVoteFromSong(Integer pollId, Integer songId, String voteType, Integer currentUserId) {
+        // 노래 조회
+        PollSong pollSong = pollSongRepository.findById(songId)
+                .orElseThrow(() -> new PollSongNotFoundException("해당 노래를 찾을 수 없습니다."));
+
+        // 투표 조회 (pollId 확인)
+        if (!pollSong.getPoll().getId().equals(pollId)) {
+            throw new PollSongNotFoundException("해당 투표에 속한 노래가 아닙니다.");
+        }
+
+        // 투표 타입 변환
+        VotedMark votedMark = convertToVotedMark(voteType);
+
+        // 사용자의 해당 타입 투표 찾기
+        Vote vote = voteRepository.findByPollSongIdAndUserIdAndVotedMark(
+                songId,
+                currentUserId,
+                votedMark
+        ).orElseThrow(() -> new VoteNotFoundException(
+                "사용자의 해당 노래에 대한 " + voteType + " 타입의 투표를 찾을 수 없습니다."
+        ));
+
+        // 투표 삭제
+        voteRepository.delete(vote);
+
+        // DB 조회 없이 해당 투표 타입의 카운트를 줄인 응답 생성
+        return convertToPollSongRespDTOWithAdjustedVote(pollSong, voteType, -1);
+    }
+
     private PollRespDTO convertToPollRespDTO(Poll poll) {
         return PollRespDTO.builder()
                 .id(poll.getId())
                 .title(poll.getTitle())
-                .clubId(poll.getClub() != null ? poll.getClub().getId() : null)
-                .clubName(poll.getClub() != null ? poll.getClub().getName() : null)
+                .clubId(
+                        poll.getClub() != null ?
+                        poll.getClub().getId() :
+                        null
+                )
+                .clubName(
+                        poll.getClub() != null ?
+                        poll.getClub().getName() :
+                        null
+                )
                 .startDatetime(poll.getStartDatetime())
                 .endDatetime(poll.getEndDatetime())
-                .creatorId(poll.getCreator() != null ? poll.getCreator().getId() : null)
-                .creatorName(poll.getCreator() != null ? poll.getCreator().getNickname() : null)
+                .creatorId(
+                        poll.getCreator() != null ?
+                        poll.getCreator().getId() :
+                        null
+                )
+                .creatorName(
+                        poll.getCreator() != null ?
+                        poll.getCreator().getNickname() :
+                        null
+                )
                 .createdAt(poll.getCreatedAt())
                 .build();
     }
@@ -125,12 +231,28 @@ public class PollService {
         return PollDetailRespDTO.builder()
                 .id(poll.getId())
                 .title(poll.getTitle())
-                .clubId(poll.getClub() != null ? poll.getClub().getId() : null)
-                .clubName(poll.getClub() != null ? poll.getClub().getName() : null)
+                .clubId(
+                        poll.getClub() != null ?
+                        poll.getClub().getId() :
+                        null
+                )
+                .clubName(
+                        poll.getClub() != null ?
+                        poll.getClub().getName() :
+                        null
+                )
                 .startDatetime(poll.getStartDatetime())
                 .endDatetime(poll.getEndDatetime())
-                .creatorId(poll.getCreator() != null ? poll.getCreator().getId() : null)
-                .creatorName(poll.getCreator() != null ? poll.getCreator().getNickname() : null)
+                .creatorId(
+                        poll.getCreator() != null ?
+                        poll.getCreator().getId() :
+                        null
+                )
+                .creatorName(
+                        poll.getCreator() != null ?
+                        poll.getCreator().getNickname() :
+                        null
+                )
                 .createdAt(poll.getCreatedAt())
                 .songs(songs)
                 .build();
@@ -139,13 +261,25 @@ public class PollService {
     private PollSongRespDTO convertToPollSongRespDTO(PollSong pollSong) {
         return PollSongRespDTO.builder()
                 .id(pollSong.getId())
-                .pollId(pollSong.getPoll() != null ? pollSong.getPoll().getId() : null)
+                .pollId(
+                        pollSong.getPoll() != null ?
+                        pollSong.getPoll().getId() :
+                        null
+                )
                 .songName(pollSong.getSongName())
                 .artistName(pollSong.getArtistName())
                 .youtubeUrl(pollSong.getYoutubeUrl())
                 .description(pollSong.getDescription())
-                .suggesterId(pollSong.getSuggester() != null ? pollSong.getSuggester().getId() : null)
-                .suggesterName(pollSong.getSuggester() != null ? pollSong.getSuggester().getNickname() : null)
+                .suggesterId(
+                        pollSong.getSuggester() != null ?
+                        pollSong.getSuggester().getId() :
+                        null
+                )
+                .suggesterName(
+                        pollSong.getSuggester() != null ?
+                        pollSong.getSuggester().getNickname() :
+                        null
+                )
                 .createdAt(pollSong.getCreatedAt())
                 .likeCount(calculateVoteCount(pollSong, "LIKE"))
                 .dislikeCount(calculateVoteCount(pollSong, "DISLIKE"))
@@ -154,9 +288,64 @@ public class PollService {
                 .build();
     }
 
+    // 특정 투표 타입의 카운트를 조정하여 DTO 반환하는 메서드 추가
+    private PollSongRespDTO convertToPollSongRespDTOWithAdjustedVote(PollSong pollSong, String voteType, int adjustment) {
+        // 기본 카운트 계산
+        int likeCount = calculateVoteCount(pollSong, "LIKE");
+        int dislikeCount = calculateVoteCount(pollSong, "DISLIKE");
+        int cantCount = calculateVoteCount(pollSong, "CANT");
+        int hajjCount = calculateVoteCount(pollSong, "HAJJ");
+
+        // 해당 투표 타입의 카운트 조정
+        switch (voteType.toUpperCase()) {
+            case "LIKE", "좋아요" -> likeCount += adjustment;
+            case "DISLIKE", "별로에요" -> dislikeCount += adjustment;
+            case "CANT", "실력부족" -> cantCount += adjustment;
+            case "HAJJ", "하고싶지_않은데_존중해요" -> hajjCount += adjustment;
+        }
+
+        return PollSongRespDTO.builder()
+                .id(pollSong.getId())
+                .pollId(
+                        pollSong.getPoll() != null ?
+                        pollSong.getPoll().getId() :
+                        null
+                )
+                .songName(pollSong.getSongName())
+                .artistName(pollSong.getArtistName())
+                .youtubeUrl(pollSong.getYoutubeUrl())
+                .description(pollSong.getDescription())
+                .suggesterId(
+                        pollSong.getSuggester() != null ?
+                        pollSong.getSuggester().getId() :
+                        null
+                )
+                .suggesterName(
+                        pollSong.getSuggester() != null ?
+                        pollSong.getSuggester().getNickname() :
+                        null
+                )
+                .createdAt(pollSong.getCreatedAt())
+                .likeCount(likeCount)
+                .dislikeCount(dislikeCount)
+                .cantCount(cantCount)
+                .hajjCount(hajjCount)
+                .build();
+    }
+
     private int calculateVoteCount(PollSong pollSong, String voteMark) {
         return (int) pollSong.getVotes().stream()
                 .filter(vote -> vote.getVotedMark().name().equals(voteMark))
                 .count();
+    }
+
+    private VotedMark convertToVotedMark(String voteType) {
+        return switch (voteType.toUpperCase()) {
+            case "LIKE", "좋아요" -> VotedMark.LIKE;
+            case "DISLIKE", "별로에요" -> VotedMark.DISLIKE;
+            case "CANT", "실력부족" -> VotedMark.CANT;
+            case "HAJJ", "하고싶지_않은데_존중해요" -> VotedMark.HAJJ;
+            default -> throw new IllegalArgumentException("유효하지 않은 투표 타입입니다: " + voteType);
+        };
     }
 }


### PR DESCRIPTION
- [x] 새로운 기능 추가
- [] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 투표 행사 관련 기능 추가

## **✅ 변경 사항**

- 커밋 참조

## **💬 코멘트**

- UPSERT 패턴으로 투표 행사/변경은 PUT으로, 투표 철회는 DELETE로 구현하였습니다.
- 투표 결과 조회는 곡 투표 폼 상세 조회의 기능과 겹친다고 판단하여 대체하였습니다.
- 그럼 '곡 투표 행사/변경 API', '곡 투표 철회 API' 두 개가 나오게 됩니다.
