### PR TITLE
feat: 동아리 부원명단 조회, 동아리 대표사진 API 작성

### DIFF
--- a/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
+++ b/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
@@ -4,6 +4,7 @@ import com.jandi.band_backend.club.dto.ClubReqDTO;
 import com.jandi.band_backend.club.dto.ClubDetailRespDTO;
 import com.jandi.band_backend.club.dto.ClubRespDTO;
 import com.jandi.band_backend.club.dto.ClubUpdateReqDTO;
+import com.jandi.band_backend.club.dto.ClubMembersRespDTO;
 import com.jandi.band_backend.club.service.ClubService;
 import com.jandi.band_backend.global.CommonResponse;
 import com.jandi.band_backend.security.CustomUserDetails;
@@ -52,6 +53,13 @@ public class ClubController {
     public ResponseEntity<CommonResponse<ClubDetailRespDTO>> getClubDetail(@PathVariable Integer clubId) {
         ClubDetailRespDTO response = clubService.getClubDetail(clubId);
         return ResponseEntity.ok(CommonResponse.success("동아리 상세 정보 조회 성공", response));
+    }
+
+    @Operation(summary = "동아리 부원 명단 조회")
+    @GetMapping("/{clubId}/members")
+    public ResponseEntity<CommonResponse<ClubMembersRespDTO>> getClubMembers(@PathVariable Integer clubId) {
+        ClubMembersRespDTO response = clubService.getClubMembers(clubId);
+        return ResponseEntity.ok(CommonResponse.success("동아리 부원 명단 조회 성공", response));
     }
 
     @Operation(summary = "동아리 정보 수정")

--- a/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
+++ b/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
@@ -86,18 +86,15 @@ public class ClubController {
         return ResponseEntity.ok(CommonResponse.success("동아리가 성공적으로 삭제되었습니다"));
     }
 
-    @Operation(summary = "동아리 대표 사진 업로드/수정")
-    @PutMapping(value = "/{clubId}/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "동아리 대표 사진 업로드")
+    @PostMapping(value = "/{clubId}/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<String>> uploadClubPhoto(
             @PathVariable Integer clubId,
             @RequestParam("image") MultipartFile image,
             @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException {
         Integer userId = userDetails.getUserId();
-        ClubService.PhotoUploadResult result = clubService.uploadClubPhoto(clubId, image, userId);
-        HttpStatus status = result.isNewPhoto() ? HttpStatus.CREATED : HttpStatus.OK;
-        String message = result.isNewPhoto() ? "동아리 대표 사진이 성공적으로 업로드되었습니다"
-                                            : "동아리 대표 사진이 성공적으로 수정되었습니다";
-        return ResponseEntity.status(status).body(CommonResponse.success(message, result.imageUrl()));
+        String imageUrl = clubService.uploadClubPhoto(clubId, image, userId);
+        return ResponseEntity.ok(CommonResponse.success("동아리 대표 사진이 성공적으로 업로드되었습니다", imageUrl));
     }
 
     @Operation(summary = "동아리 대표 사진 삭제")

--- a/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
+++ b/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
@@ -87,7 +87,7 @@ public class ClubController {
     }
 
     @Operation(summary = "동아리 대표 사진 업로드")
-    @PostMapping(value = "/{clubId}/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/{clubId}/main-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<String>> uploadClubPhoto(
             @PathVariable Integer clubId,
             @RequestParam("image") MultipartFile image,
@@ -98,7 +98,7 @@ public class ClubController {
     }
 
     @Operation(summary = "동아리 대표 사진 삭제")
-    @DeleteMapping("/{clubId}/photo")
+    @DeleteMapping("/{clubId}/main-image")
     public ResponseEntity<CommonResponse<Void>> deleteClubPhoto(
             @PathVariable Integer clubId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/jandi/band_backend/club/dto/ClubMembersRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/club/dto/ClubMembersRespDTO.java
@@ -1,0 +1,33 @@
+package com.jandi.band_backend.club.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubMembersRespDTO {
+    private Integer id;
+    private List<MemberInfoDTO> members;
+    private Integer vocalCount;
+    private Integer guitarCount;
+    private Integer keyboardCount;
+    private Integer bassCount;
+    private Integer drumCount;
+    private Integer totalMemberCount;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberInfoDTO {
+        private Integer userId;
+        private String name;
+        private String position;
+    }
+}

--- a/src/main/java/com/jandi/band_backend/club/entity/ClubPhoto.java
+++ b/src/main/java/com/jandi/band_backend/club/entity/ClubPhoto.java
@@ -30,7 +30,7 @@ public class ClubPhoto {
     @Column(name = "is_current", nullable = false)
     private Boolean isCurrent = true;
 
-    @Column(name = "uploaded_at", nullable = false, updatable = false)
+    @Column(name = "uploaded_at", nullable = false)
     private LocalDateTime uploadedAt;
 
     @Column(name = "deleted_at")

--- a/src/main/java/com/jandi/band_backend/club/service/ClubService.java
+++ b/src/main/java/com/jandi/band_backend/club/service/ClubService.java
@@ -96,14 +96,12 @@ public class ClubService {
 
     @Transactional(readOnly = true)
     public Page<ClubRespDTO> getClubList(Pageable pageable) {
-        // deletedAt이 null인 동아리만 조회하도록 수정
+        // 동아리 목록 조회
         Page<Club> clubPage = clubRepository.findAllByDeletedAtIsNull(pageable);
 
         return clubPage.map(club -> {
-            // 동아리 대표 사진 URL 조회
             String photoUrl = getClubMainPhotoUrl(club.getId());
-
-            int memberCount = club.getClubMembers().size();
+            int memberCount = clubMemberRepository.countByClubId(club.getId());
 
             return convertToClubRespDTO(club, photoUrl, memberCount);
         });
@@ -111,13 +109,12 @@ public class ClubService {
 
     @Transactional(readOnly = true)
     public ClubDetailRespDTO getClubDetail(Integer clubId) {
+        // 동아리 상세 조회
         Club club = clubRepository.findByIdAndDeletedAtIsNull(clubId)
                 .orElseThrow(() -> new ClubNotFoundException("동아리를 찾을 수 없습니다."));
 
-        int memberCount = clubMemberRepository.countByClubId(clubId);
-
-        // 동아리 대표 사진 URL 조회
         String photoUrl = getClubMainPhotoUrl(club.getId());
+        int memberCount = clubMemberRepository.countByClubId(clubId);
 
         return convertToClubDetailRespDTO(club, photoUrl, memberCount);
     }

--- a/src/main/java/com/jandi/band_backend/club/service/ClubService.java
+++ b/src/main/java/com/jandi/band_backend/club/service/ClubService.java
@@ -163,9 +163,8 @@ public class ClubService {
         Club club = clubRepository.findByIdAndDeletedAtIsNull(clubId)
                 .orElseThrow(() -> new ClubNotFoundException("동아리를 찾을 수 없습니다."));
 
-        // 권한 확인 (대표자만 수정 가능)
+        // 권한 확인 (동아리 회원이면 수정 가능)
         clubMemberRepository.findByClubIdAndUserId(clubId, userId)
-                .filter(member -> member.getRole() == ClubMember.MemberRole.REPRESENTATIVE)
                 .orElseThrow(() -> new UnauthorizedClubAccessException("동아리 정보 수정 권한이 없습니다."));
 
         // 동아리 정보 수정
@@ -219,9 +218,8 @@ public class ClubService {
         Club club = clubRepository.findByIdAndDeletedAtIsNull(clubId)
                 .orElseThrow(() -> new ClubNotFoundException("동아리를 찾을 수 없습니다."));
 
-        // 권한 확인 (대표자만 업로드 가능)
+        // 권한 확인 (동아리 회원이면 업로드 가능)
         clubMemberRepository.findByClubIdAndUserId(clubId, userId)
-                .filter(member -> member.getRole() == ClubMember.MemberRole.REPRESENTATIVE)
                 .orElseThrow(() -> new UnauthorizedClubAccessException("동아리 사진 업로드 권한이 없습니다."));
 
         // 기존 사진 존재 여부 확인
@@ -252,9 +250,8 @@ public class ClubService {
         Club club = clubRepository.findByIdAndDeletedAtIsNull(clubId)
                 .orElseThrow(() -> new ClubNotFoundException("동아리를 찾을 수 없습니다."));
 
-        // 권한 확인 (대표자만 삭제 가능)
+        // 권한 확인 (동아리 회원이면 삭제 가능)
         clubMemberRepository.findByClubIdAndUserId(clubId, userId)
-                .filter(member -> member.getRole() == ClubMember.MemberRole.REPRESENTATIVE)
                 .orElseThrow(() -> new UnauthorizedClubAccessException("동아리 사진 삭제 권한이 없습니다."));
 
         ClubPhoto photo = clubPhotoRepository.findByClubIdAndIsCurrentTrueAndDeletedAtIsNull(clubId)


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 동아리 부원명단 조회 API
- 동아리 대표사진 업로드/삭제 API

## **✅ 변경 사항**

- 부원 명단조회에 포함된 내용
  - 포지션별 통계: VOCAL, GUITAR, KEYBOARD, BASS, DRUM 각각 카운트
  - 총 부원 수: 전체 동아리 멤버 수 제공
  -  부원 정보: userId, name, position 포함
- 동아리 대표사진 관련된 내용
  - 업로드(POST): 원래 사진 S3에서 지우고, 새 사진 S3에 저장한 후 새 사진으로 이미지url 등록
  - 삭제(DELETE): 원래 사진 S3에서 지우고, 기본 이미지로 이미지url 되돌림 (참고: 기본 이미지는 기본 이미지로 되돌림)

## **💬 코멘트(참고 사항)**

- 동아리 대표사진 관련된 내용 추가
  - 동아리 생성/삭제 시: club_photo 테이블에서 새 레코드 생성함 / 레코드 소프트 삭제함
      - 동아리 생성할 땐 기본 이미지 들어감 (-> S3에 넣을 기본 이미지 논의 필요, 아직 임시로 지정)
      - 동아리 삭제할 땐 위의 삭제(DELETE) 기능 적용함. 그 뒤 동아리가 삭제됨
  - 동아리 대표사진 업로드/삭제 시: 기존 레코드 업데이트함
      - 대표사진 삭제 API 작동할 때 대표사진이 기본 이미지면 S3에서 삭제 안되게끔 코드 작성함
