### PR TITLE
feat: 로그인 API 구현

### DIFF
--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
         return CommonResponse.success("로그인 성공", tokens);
     }
 
-    @Operation(summary = "회원가입")
+    @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public CommonResponse<String> logout(
             @RequestHeader("Authorization") String token
@@ -50,6 +50,7 @@ public class AuthController {
 
     }
 
+    @Operation(summary = "회원가입")
     @PostMapping("/signup")
     public CommonResponse<UserInfoDTO> signUp(
             @RequestHeader("Authorization") String token,

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -3,6 +3,10 @@ package com.jandi.band_backend.auth.controller;
 import com.jandi.band_backend.auth.dto.TokenRespDTO;
 import com.jandi.band_backend.auth.dto.RefreshReqDTO;
 import com.jandi.band_backend.auth.dto.SignUpReqDTO;
+import com.jandi.band_backend.auth.dto.kakao.KakaoTokenRespDTO;
+import com.jandi.band_backend.auth.dto.kakao.KakaoUserInfoDTO;
+import com.jandi.band_backend.auth.service.kakao.KaKaoTokenService;
+import com.jandi.band_backend.auth.service.kakao.KakaoUserService;
 import com.jandi.band_backend.global.CommonResponse;
 import com.jandi.band_backend.user.dto.UserInfoDTO;
 import com.jandi.band_backend.auth.service.AuthService;
@@ -18,6 +22,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final KaKaoTokenService kaKaoTokenService;
+    private final KakaoUserService kakaoUserService;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(summary = "카카오 로그인")
@@ -25,7 +31,11 @@ public class AuthController {
     public CommonResponse<TokenRespDTO> kakaoLogin(
             @RequestParam String code
     ){
-        TokenRespDTO tokens = authService.login(code);
+        // 카카오로부터 유저 정보 얻기
+        KakaoTokenRespDTO kakaoToken = kaKaoTokenService.getKakaoToken(code);
+        KakaoUserInfoDTO kakaoUserInfo = kakaoUserService.getKakaoUserInfo(kakaoToken.getAccessToken());
+
+        TokenRespDTO tokens = authService.login(kakaoUserInfo);
         return CommonResponse.success("로그인 성공", tokens);
     }
 


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes `#BACK_AA_003`

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 로그아웃 API 작업

## **✅ 변경 사항**


## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 멘토분께서 말씀하셨다시피, 현재 서비스에선 굳이 블랙리스트를 관리할 필요가 없다고 하셔서 로깅만 하는 것으로 구현했습니다
- 카카오 로그아웃에 대해 찾아본 결과, 카카오에서 발급하는 카카오 토큰은 로그인 및 유저 정보를 가져올 때만 쓰이고 알림톡을 발송하거나 카카오 공유 링크를 생성하는데에는 관련이 없어서 굳이 로그아웃 안해도 될거같습니다. 어차피 카카오 토큰은 별도의 장소에 저장하고 있지 않아서 애매하기도 해서 구현 안했습니다!
