### PR TITLE
feat: 회원탈퇴 구현

### DIFF
--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -62,6 +62,17 @@ public class AuthController {
         return CommonRespDTO.success("회원가입 성공", userInfo);
     }
 
+    @Operation(summary = "회원탈퇴")
+    @PostMapping("/cancel")
+    public CommonRespDTO<UserInfoDTO> cancel(
+            @RequestHeader("Authorization") String token
+    ){
+        String accessToken = token.replace("Bearer ", "");
+        String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
+        authService.cancel(kakaoOauthId);
+        return CommonRespDTO.success("회원탈퇴 성공");
+    }
+
     @Operation(summary = "토큰 재발급")
     @PostMapping("/refresh")
     public CommonRespDTO<TokenRespDTO> refresh(

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -8,12 +8,14 @@ import com.jandi.band_backend.auth.dto.kakao.KakaoUserInfoDTO;
 import com.jandi.band_backend.auth.service.kakao.KaKaoTokenService;
 import com.jandi.band_backend.auth.service.kakao.KakaoUserService;
 import com.jandi.band_backend.global.dto.CommonRespDTO;
+import com.jandi.band_backend.security.CustomUserDetails;
 import com.jandi.band_backend.user.dto.UserInfoDTO;
 import com.jandi.band_backend.auth.service.AuthService;
 import com.jandi.band_backend.security.jwt.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth API")
@@ -53,12 +55,11 @@ public class AuthController {
     @Operation(summary = "회원가입")
     @PostMapping("/signup")
     public CommonRespDTO<UserInfoDTO> signUp(
-            @RequestHeader("Authorization") String token,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody SignUpReqDTO signUpReqDTO
     ){
-        String accessToken = token.replace("Bearer ", "");
-        String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
-        UserInfoDTO userInfo = authService.signup(kakaoOauthId, signUpReqDTO);
+        Integer userId = userDetails.getUserId();
+        UserInfoDTO userInfo = authService.signup(userId, signUpReqDTO);
         return CommonRespDTO.success("회원가입 성공", userInfo);
     }
 

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -66,11 +66,10 @@ public class AuthController {
     @Operation(summary = "회원탈퇴")
     @PostMapping("/cancel")
     public CommonRespDTO<UserInfoDTO> cancel(
-            @RequestHeader("Authorization") String token
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ){
-        String accessToken = token.replace("Bearer ", "");
-        String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
-        authService.cancel(kakaoOauthId);
+        Integer userId = userDetails.getUserId();
+        authService.cancel(userId);
         return CommonRespDTO.success("회원탈퇴 성공");
     }
 

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -44,10 +44,10 @@ public class AuthController {
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public CommonRespDTO<String> logout(
-            @RequestHeader("Authorization") String token
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ){
-        String accessToken = token.replace("Bearer ", "");
-        authService.logout(accessToken);
+        Integer userId = userDetails.getUserId();
+        authService.logout(userId);
         return CommonRespDTO.success("로그아웃 완료");
 
     }

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -49,7 +49,6 @@ public class AuthController {
         Integer userId = userDetails.getUserId();
         authService.logout(userId);
         return CommonRespDTO.success("로그아웃 완료");
-
     }
 
     @Operation(summary = "회원가입")

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -51,13 +51,12 @@ public class AuthService {
     }
 
     /// 로그아웃
-    public void logout(String accessToken) {
+    public void logout(Integer userId) {
         // 멘토링 결과 별도의 블랙리스트 처리는 필요하지 않아 로깅만 하는 것으로 작업
         // 카카오 토큰은 카카오 리소스 접근용이라 알림톡/메시지 공유에선 쓰이지 않아 굳이 카카오에게 로그아웃을 요청해 강제 만료처리할 필요가 없음
-        String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
-        userRepository.findByKakaoOauthIdAndDeletedAtIsNull(kakaoOauthId)
+        Users user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        log.info("사용자: {}가 로그아웃했습니다", kakaoOauthId);
+        log.info("KakaoOauthId: {}가 로그아웃 요청", user.getKakaoOauthId());
     }
 
     /// 정식 회원가입

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -108,8 +108,12 @@ public class AuthService {
             throw new InvalidTokenException();
         }
 
-        // 토큰 재발급
+        // 유저 검증
         String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(refreshToken);
+        userRepository.findByKakaoOauthIdAndDeletedAtIsNull(kakaoOauthId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 토큰 재발급
         return new TokenRespDTO(
                 jwtTokenProvider.generateAccessToken(kakaoOauthId),
                 jwtTokenProvider.ReissueRefreshToken(refreshToken)

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -90,16 +90,16 @@ public class AuthService {
 
     /// 회원탈퇴
     @Transactional
-    public void cancel(String kakaoOauthId) {
+    public void cancel(Integer userId) {
         // DB에서 탈퇴 처리
-        Users user = userRepository.findByKakaoOauthIdAndDeletedAtIsNull(kakaoOauthId)
+        Users user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         user.setIsRegistered(false);
         user.setDeletedAt(LocalDateTime.now());
         userRepository.save(user);
 
         // 카카오와 연결 끊기
-        kakaoUserService.unlink(kakaoOauthId);
+        kakaoUserService.unlink(user.getKakaoOauthId());
     }
 
     /// 리프레시 토큰 생성

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -55,6 +55,8 @@ public class AuthService {
         // 멘토링 결과 별도의 블랙리스트 처리는 필요하지 않아 로깅만 하는 것으로 작업
         // 카카오 토큰은 카카오 리소스 접근용이라 알림톡/메시지 공유에선 쓰이지 않아 굳이 카카오에게 로그아웃을 요청해 강제 만료처리할 필요가 없음
         String kakaoOauthId = jwtTokenProvider.getKakaoOauthId(accessToken);
+        userRepository.findByKakaoOauthIdAndDeletedAtIsNull(kakaoOauthId)
+                .orElseThrow(UserNotFoundException::new);
         log.info("사용자: {}가 로그아웃했습니다", kakaoOauthId);
     }
 
@@ -62,7 +64,7 @@ public class AuthService {
     @Transactional
     public UserInfoDTO signup(String kakaoOauthId, SignUpReqDTO reqDTO) {
         // 유저 조회
-        Users user = userRepository.findByKakaoOauthId(kakaoOauthId)
+        Users user = userRepository.findByKakaoOauthIdAndDeletedAtIsNull(kakaoOauthId)
                 .orElseThrow(UserNotFoundException::new);
 
         // 회원가입 여부 확인 -> 정식 회원가입 완료한 기존 회원이라면 진행하지 않음
@@ -91,7 +93,7 @@ public class AuthService {
     @Transactional
     public void cancel(String kakaoOauthId) {
         // DB에서 탈퇴 처리
-        Users user = userRepository.findByKakaoOauthId(kakaoOauthId)
+        Users user = userRepository.findByKakaoOauthIdAndDeletedAtIsNull(kakaoOauthId)
                 .orElseThrow(UserNotFoundException::new);
         user.setIsRegistered(false);
         user.setDeletedAt(LocalDateTime.now());

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.jandi.band_backend.auth.dto.kakao.KakaoUserInfoDTO;
 import com.jandi.band_backend.auth.service.kakao.KakaoUserService;
 import com.jandi.band_backend.global.exception.InvalidAccessException;
 import com.jandi.band_backend.global.exception.InvalidTokenException;
+import com.jandi.band_backend.global.exception.UniversityNotFoundException;
 import com.jandi.band_backend.global.exception.UserNotFoundException;
 import com.jandi.band_backend.security.jwt.JwtTokenProvider;
 import com.jandi.band_backend.univ.entity.University;
@@ -72,8 +73,11 @@ public class AuthService {
         }
 
         // 기본 유저 정보 입력
-        University university = universityRepository.findByName(reqDTO.getUniversity());
         Users.Position position = Users.Position.valueOf(reqDTO.getPosition());
+        University university = universityRepository.findByName(reqDTO.getUniversity());
+        if(university == null) {
+            throw new UniversityNotFoundException(("존재하지 않는 대학입니다: " + reqDTO.getUniversity()));
+        }
 
         user.setUniversity(university);
         user.setPosition(position);

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -62,9 +62,9 @@ public class AuthService {
 
     /// 정식 회원가입
     @Transactional
-    public UserInfoDTO signup(String kakaoOauthId, SignUpReqDTO reqDTO) {
+    public UserInfoDTO signup(Integer userId, SignUpReqDTO reqDTO) {
         // 유저 조회
-        Users user = userRepository.findByKakaoOauthIdAndDeletedAtIsNull(kakaoOauthId)
+        Users user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
         // 회원가입 여부 확인 -> 정식 회원가입 완료한 기존 회원이라면 진행하지 않음
@@ -81,7 +81,7 @@ public class AuthService {
         user.setIsRegistered(true);
         userRepository.save(user);
 
-        log.info("KakaoOauthId: {}에 대해 정식 회원 가입 완료", kakaoOauthId);
+        log.info("KakaoOauthId: {}에 대해 정식 회원 가입 완료", user.getKakaoOauthId());
 
         // 유저 정보 반환: 유저 기본 정보, 유저 프로필
         return new UserInfoDTO(

--- a/src/main/java/com/jandi/band_backend/auth/service/kakao/KakaoUserService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/kakao/KakaoUserService.java
@@ -4,24 +4,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jandi.band_backend.auth.dto.kakao.KakaoUserInfoDTO;
 import com.jandi.band_backend.global.exception.FailKakaoLoginException;
 import com.jandi.band_backend.global.exception.FailKakaoReadUserException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+@Slf4j
 @Service
 public class KakaoUserService {
     @Value("${kakao.user-info-url}")
     private String kakaoUserInfoUri;
+    @Value("${kakao.user-unlink-url}")
+    private String kakaoUserUnlinkUri;
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
 
     // 카카오 서버로부터 유저 정보 얻기
     public KakaoUserInfoDTO getKakaoUserInfo(String accessToken){
@@ -40,31 +46,38 @@ public class KakaoUserService {
         );
     }
 
-    /// 내부 메소드
-    // 카카오 계정 정보 조회를 위한 HTTP 요청 전송
-    private ResponseEntity<Map> responseForm(String accessToken){
-        // 헤더에 Authorization 추가
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
-
-        // 요청 전송
-        RestTemplate restTemplate = new RestTemplate();
-        return restTemplate.exchange(
-                kakaoUserInfoUri,
-                HttpMethod.GET,
-                new HttpEntity<>(headers),
-                Map.class
-        );
+    // 카카오 계정 연결 끊기
+    public void unlink(String kakaoOauthId) {
+        // 액세스 토큰으로 유저 정보 요청 보내기
+        Map body = requestKakaoUserUnlink(kakaoOauthId);
+        log.info("body: {}", body);
+        // 응답 검토
+        String returnedId = String.valueOf(body.get("id"));
+        if(returnedId == null || !returnedId.equals(kakaoOauthId)) {
+            throw new FailKakaoReadUserException("카카오 연결 끊기 실패: 아이디가 일치하지 않습니다");
+        }
     }
 
+    /// 내부 메소드
     // 카카오 토큰으로 카카오 계정 정보 요청 및 예외 핸들링
     // 정상일 경우 Map 반환, 오류 발생 시 FailKakaoReadUserException 예외를 던짐
     private Map requestKakaoUserInfo(String accessToken){
         try {
-            ResponseEntity<Map> response = responseForm(accessToken);
+            // 헤더에 Authorization 추가
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+
+            // 요청 전송
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    kakaoUserInfoUri,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    Map.class
+            );
 
             if (!response.getStatusCode().is2xxSuccessful()) {
-                throw new FailKakaoReadUserException("카카오 사용자 정보 조회 실패: " + response.getStatusCode());
+                throw new FailKakaoReadUserException("카카오 연결 끊기 실패: " + response.getStatusCode());
             }
 
             return Optional.ofNullable(response.getBody())
@@ -80,9 +93,51 @@ public class KakaoUserService {
                 throw new FailKakaoLoginException("카카오 응답 파싱 실패");
             }
         }
-
-
-
     }
+
+    // 회원탈퇴
+    private Map requestKakaoUserUnlink(String kakaoOauthId) {
+        try {
+            // 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+            // 바디 파라미터 설정 (user_id 고정)
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("target_id_type", "user_id");
+            body.add("target_id", kakaoOauthId);
+
+            // 요청 생성
+            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+            // RestTemplate로 POST 요청
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<Map> response = restTemplate.postForEntity(
+                    kakaoUserUnlinkUri,
+                    request,
+                    Map.class
+            );
+
+            log.info("response: {}", response);
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new FailKakaoReadUserException("카카오 사용자 연결 끊기 실패: " + response.getStatusCode());
+            }
+
+            return Optional.ofNullable(response.getBody())
+                    .orElseThrow(() -> new FailKakaoReadUserException("카카오 응답 없음"));
+
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            try {
+                Map errorBody = new ObjectMapper().readValue(e.getResponseBodyAsString(), Map.class);
+                throw new FailKakaoLoginException(errorBody);
+            } catch (IOException ex) {
+                throw new FailKakaoLoginException("카카오 응답 파싱 실패");
+            }
+        }
+    }
+
 }
 

--- a/src/main/java/com/jandi/band_backend/security/CustomUserDetails.java
+++ b/src/main/java/com/jandi/band_backend/security/CustomUserDetails.java
@@ -20,7 +20,6 @@ public class CustomUserDetails implements UserDetails {
     }
 
     public Integer getUserId() {
-        log.info("deletedAt raw value: {}", user.getDeletedAt());
         if(user.getDeletedAt() != null) {
             throw new UserNotFoundException("유저 정보가 존재하지 않습니다: 탈퇴한 회원입니다.");
         }

--- a/src/main/java/com/jandi/band_backend/security/CustomUserDetails.java
+++ b/src/main/java/com/jandi/band_backend/security/CustomUserDetails.java
@@ -1,6 +1,8 @@
 package com.jandi.band_backend.security;
 
+import com.jandi.band_backend.global.exception.UserNotFoundException;
 import com.jandi.band_backend.user.entity.Users;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
+@Slf4j
 public class CustomUserDetails implements UserDetails {
 
     private final Users user;
@@ -17,6 +20,10 @@ public class CustomUserDetails implements UserDetails {
     }
 
     public Integer getUserId() {
+        log.info("deletedAt raw value: {}", user.getDeletedAt());
+        if(user.getDeletedAt() != null) {
+            throw new UserNotFoundException("유저 정보가 존재하지 않습니다: 탈퇴한 회원입니다.");
+        }
         return user.getId();
     }
 

--- a/src/main/java/com/jandi/band_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/jandi/band_backend/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<Users, Integer> {
     Optional<Users> findById(Integer id);
     Optional<Users> findByKakaoOauthId(String kakaoOauthId);
+
+    Optional<Users> findByKakaoOauthIdAndDeletedAtIsNull(String kakaoOauthId);
 }


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #이슈번호

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 회원탈퇴 구현: 회원탈퇴 시 카카오 계정 연결도 끊어지게 했습니다
- auth 도메인 쪽도 kakaoOauthId 대신 userId를 쓰는 것으로 통일했습니다
- 회원가입 시 대학정보 혹은 포지션을 잘못 입력하면 예외내도록 처리했습니다

## **✅ 변경 사항**

- 추가된 환경 변수 2개 있습니다! 디코에 메시지남겨두겠습니다
- 회원 탈퇴되면 유저 조회가 불가능해야 하므로, userDetail에 조건문을 추가하여 탈퇴된 회원은 예외를 던지도록 했습니다

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 카카오 연결 끊기를 하려면 앱 어드민 키 혹은 카카오 자체 토큰이 필요한데, 후자를 택하면 유저 입장에선 회원탈퇴 시 한번 더 카카오로그인을 거쳐야 하는? 그러려면 프론트 업무도 좀 추가될거같아서 그냥 어드민키를 넣어서 처리했습니다...만 서버에서 보내는 거니까 보안상 괜찮겠죠?!
