### PR TITLE
feat: 공연 홍보 지도 검색 API 추가

### DIFF
--- a/src/main/java/com/jandi/band_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/band_backend/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/**",
                                 "/health",
+                                "/api/clubs/**",
                                 "/api/images/**",
                                 "/api/promos",           // 공연 홍보 목록 조회
                                 "/api/promos/{promoId}", // 공연 홍보 상세 조회
@@ -61,8 +62,6 @@ public class SecurityConfig {
                                 // Actuator 모니터링 엔드포인트 (Prometheus & Grafana)
                                 "/actuator/**"
                         ).permitAll()
-                        // 동아리 관련 API 중 공개적으로 접근 가능한 것들 (동아리 목록 조회 등)
-                        .requestMatchers(HttpMethod.GET, "/api/clubs", "/api/clubs/{clubId}").permitAll()
                         // CORS preflight 요청 허용
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/jandi/band_backend/promo/controller/PromoController.java
+++ b/src/main/java/com/jandi/band_backend/promo/controller/PromoController.java
@@ -68,6 +68,8 @@ public class PromoController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime eventDatetime,
             @RequestParam(required = false) String location,
             @RequestParam(required = false) String address,
+            @RequestParam(required = false) BigDecimal latitude,
+            @RequestParam(required = false) BigDecimal longitude,
             @RequestParam(required = false) String description,
             @RequestParam(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -79,6 +81,8 @@ public class PromoController {
         request.setEventDatetime(eventDatetime);
         request.setLocation(location);
         request.setAddress(address);
+        request.setLatitude(latitude);
+        request.setLongitude(longitude);
         request.setDescription(description);
         request.setImage(image);
         
@@ -158,6 +162,25 @@ public class PromoController {
         Pageable pageable = createPageable(page, size, sort);
         Integer userId = userDetails != null ? userDetails.getUserId() : null;
         Page<PromoRespDTO> promoPage = promoService.filterPromos(startDate, endDate, teamName, userId, pageable);
+        return ResponseEntity.ok(CommonRespDTO.success("공연 홍보 필터링 성공",
+                PagedRespDTO.from(promoPage)));
+    }
+
+    @Operation(summary = "공연 홍보 지도상 검색")
+    @GetMapping("/map")
+    public ResponseEntity<CommonRespDTO<PagedRespDTO<PromoRespDTO>>> filterMapPromos(
+            @RequestParam BigDecimal startLatitude,
+            @RequestParam BigDecimal startLongitude,
+            @RequestParam BigDecimal endLatitude,
+            @RequestParam BigDecimal endLongitude,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "createdAt,desc") String sort,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Pageable pageable = createPageable(page, size, sort);
+        Integer userId = userDetails != null ? userDetails.getUserId() : null;
+        Page<PromoRespDTO> promoPage = promoService.filterMapPromos(startLatitude, startLongitude, endLatitude, endLongitude, userId, pageable);
         return ResponseEntity.ok(CommonRespDTO.success("공연 홍보 필터링 성공",
                 PagedRespDTO.from(promoPage)));
     }

--- a/src/main/java/com/jandi/band_backend/promo/dto/PromoReqDTO.java
+++ b/src/main/java/com/jandi/band_backend/promo/dto/PromoReqDTO.java
@@ -39,6 +39,12 @@ public class PromoReqDTO {
     @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다")
     private String address;
 
+    @Schema(description = "위도", example = "37.537183")
+    private BigDecimal latitude;
+
+    @Schema(description = "경도", example = "37.537183")
+    private BigDecimal longitude;
+
     @Schema(description = "공연 설명", example = "락밴드 동아리의 정기 공연입니다. 다양한 장르의 음악을 선보일 예정입니다.")
     private String description;
 

--- a/src/main/java/com/jandi/band_backend/promo/dto/PromoRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/promo/dto/PromoRespDTO.java
@@ -41,6 +41,12 @@ public class PromoRespDTO {
     
     @Schema(description = "상세 주소", example = "서울시 마포구 홍익로 123")
     private String address;
+
+    @Schema(description = "위도", example = "126.99597295767953")
+    private BigDecimal latitude;
+
+    @Schema(description = "경도", example = "35.97664845766847")
+    private BigDecimal longitude;
     
     @Schema(description = "공연 설명", example = "락밴드 동아리의 정기 공연입니다.")
     private String description;
@@ -88,6 +94,8 @@ public class PromoRespDTO {
                 .filter(photo -> photo.getDeletedAt() == null)  // 삭제되지 않은 사진만 포함
                 .map(photo -> photo.getImageUrl())
                 .collect(Collectors.toList()));
+        response.setLatitude(promo.getLatitude());
+        response.setLongitude(promo.getLongitude());
         return response;
     }
 

--- a/src/main/java/com/jandi/band_backend/promo/entity/Promo.java
+++ b/src/main/java/com/jandi/band_backend/promo/entity/Promo.java
@@ -46,10 +46,16 @@ public class Promo {
     
     @Column(name = "location", length = 255)
     private String location;
-    
+
     @Column(name = "address", length = 255)
     private String address;
-    
+
+    @Column(name = "latitude", precision = 17, scale = 14)
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 17, scale = 14)
+    private BigDecimal longitude;
+
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
     

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Repository
@@ -59,4 +60,17 @@ public interface PromoRepository extends JpaRepository<Promo, Integer> {
         @Param("endDate") LocalDateTime endDate,
         @Param("teamName") String teamName,
         Pageable pageable);
+
+    // 특정 지역 범위에 속한 것만 필터링
+    @Query("SELECT p FROM Promo p " +
+            "WHERE p.latitude BETWEEN :minLat AND :maxLat " +
+            "AND p.longitude BETWEEN :minLng AND :maxLng " +
+            "AND p.deletedAt IS NULL")
+    Page<Promo> filterPromosInSpecArea(
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLng") BigDecimal minLng,
+            @Param("maxLng") BigDecimal maxLng,
+            Pageable pageable
+    );
 } 


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- 트러블슈팅 해결

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 공연 홍보 지도 검색 API 추가

## **✅ 변경 사항**

- promo에 latitude, longitude 컬럼 추가 -> decimal(17, 14)
-> 카카오 개발문서 보니 14자리까지 넘겨주길래 맞춰줌
- createPromo 메서드에서 latitude, longitude을 추가로 입력받도록 수정
- PromoRespDTO에 latitude, longitude를 추가하여 응답에 위경도 보이게 수정
## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 리뷰 시 참고하거나 봐줬으면 하는 부분이 있다면 작성해주세요.
