### PR TITLE
fix: 프론트 요구 반영

### DIFF
--- a/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDTO.java
@@ -5,17 +5,17 @@ import lombok.Data;
 
 @Data
 public class ClubGalPhotoRespDTO {
-    private Integer photo_id;
-    private Integer uploader_id;
-    private String uploader_name;
+    private Integer photoId;
+    private Integer uploaderId;
+    private String uploaderName;
     private String imageUrl;
     private Boolean isPinned;
     private Boolean isPublic;
 
     public ClubGalPhotoRespDTO(ClubGalPhoto photo) {
-        photo_id = photo.getId();
-        uploader_id = photo.getUploader().getId();
-        uploader_name = photo.getUploader().getNickname();
+        photoId = photo.getId();
+        uploaderId = photo.getUploader().getId();
+        uploaderName = photo.getUploader().getNickname();
         imageUrl = photo.getImageUrl();
         isPinned = photo.getIsPinned();
         isPublic = photo.getIsPublic();

--- a/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDTO.java
@@ -5,13 +5,17 @@ import lombok.Data;
 
 @Data
 public class ClubGalPhotoRespDTO {
-    private Integer id;
+    private Integer photo_id;
+    private Integer uploader_id;
+    private String uploader_name;
     private String imageUrl;
     private Boolean isPinned;
     private Boolean isPublic;
 
     public ClubGalPhotoRespDTO(ClubGalPhoto photo) {
-        id = photo.getId();
+        photo_id = photo.getId();
+        uploader_id = photo.getUploader().getId();
+        uploader_name = photo.getUploader().getNickname();
         imageUrl = photo.getImageUrl();
         isPinned = photo.getIsPinned();
         isPublic = photo.getIsPublic();

--- a/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDetailDTO.java
+++ b/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDetailDTO.java
@@ -9,8 +9,9 @@ import java.time.LocalDateTime;
 @Data
 @AllArgsConstructor
 public class ClubGalPhotoRespDetailDTO {
-    private Integer id;
-    private String uploader;
+    private Integer photo_id;
+    private Integer uploader_id;
+    private String uploader_name;
     private String imageUrl;
     private String description;
     private Boolean isPinned;
@@ -18,8 +19,9 @@ public class ClubGalPhotoRespDetailDTO {
     private LocalDateTime uploadedAt;
 
     public ClubGalPhotoRespDetailDTO(ClubGalPhoto photo) {
-        id = photo.getId();
-        uploader = photo.getUploader().getNickname();
+        photo_id = photo.getId();
+        uploader_id = photo.getUploader().getId();
+        uploader_name = photo.getUploader().getNickname();
         imageUrl = photo.getImageUrl();
         description = photo.getDescription();
         isPinned = photo.getIsPinned();

--- a/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDetailDTO.java
+++ b/src/main/java/com/jandi/band_backend/club/dto/ClubGalPhotoRespDetailDTO.java
@@ -9,9 +9,9 @@ import java.time.LocalDateTime;
 @Data
 @AllArgsConstructor
 public class ClubGalPhotoRespDetailDTO {
-    private Integer photo_id;
-    private Integer uploader_id;
-    private String uploader_name;
+    private Integer photoId;
+    private Integer uploaderId;
+    private String uploaderName;
     private String imageUrl;
     private String description;
     private Boolean isPinned;
@@ -19,9 +19,9 @@ public class ClubGalPhotoRespDetailDTO {
     private LocalDateTime uploadedAt;
 
     public ClubGalPhotoRespDetailDTO(ClubGalPhoto photo) {
-        photo_id = photo.getId();
-        uploader_id = photo.getUploader().getId();
-        uploader_name = photo.getUploader().getNickname();
+        photoId = photo.getId();
+        uploaderId = photo.getUploader().getId();
+        uploaderName = photo.getUploader().getNickname();
         imageUrl = photo.getImageUrl();
         description = photo.getDescription();
         isPinned = photo.getIsPinned();


### PR DESCRIPTION
프론트 요구대로 uloader_id, uploader_name 둘다 보내지도록 수정

## **🔗 관련 이슈 번호**

- [트러블슈팅 해결](https://www.notion.so/1e4be199511b81e58630e2eaacb66f24?p=20fbe199511b8089b908db5d67bc3090&pm=s)

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 어떤 작업을 했는지 간단히 설명해주세요.

## **✅ 변경 사항**

- clubGalPhotoRespDTO, clubGalPhotoRespDetailDTO에 업로더 id, name 변수 추가
- 혼돈을 막기 위해 기존 변수 id -> photoId로 변경

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 리뷰 시 참고하거나 봐줬으면 하는 부분이 있다면 작성해주세요.
