### PR TITLE
feat: 회원탈퇴 로직을 확장함

### DIFF
--- a/docs/auth-auth.md
+++ b/docs/auth-auth.md
@@ -112,7 +112,7 @@ curl -X POST "http://localhost:8080/api/auth/signup" \
 
 ---
 
-## 4. 회원탈퇴
+## 4. 회원탈퇴 (확장된 3단계 처리)
 ```
 POST /api/auth/cancel
 Authorization: Bearer {JWT_TOKEN}
@@ -132,6 +132,56 @@ curl -X POST "http://localhost:8080/api/auth/cancel" \
   "data": null
 }
 ```
+
+### 회원탈퇴 처리 방식
+
+#### **사전 검증**
+- 동아리 대표자는 탈퇴 불가 (먼저 대표자 권한 위임 필요)
+- 카카오 OAuth 연결 해제
+
+#### **그룹 1: 개인 종속 데이터 (소프트 삭제)**
+즉시 소프트 삭제 처리 (deleted_at 설정), 7일 후 cronjob으로 하드 삭제 예정
+
+**대상 테이블:**
+- `users`: 사용자 기본 정보
+- `user_photo`: 사용자 프로필 사진
+- `user_timetable`: 사용자 시간표
+- `club_member`: 동아리 멤버십
+- `team_member`: 팀 멤버십
+
+#### **그룹 2: 콘텐츠 소유권 (익명화 처리)**
+즉시 user_id 관련 필드를 -1로 변경하여 익명화
+
+**대상 테이블:**
+- `club_gal_photo`: 동아리 갤러리 사진
+- `club_event`: 동아리 이벤트
+- `poll`: 투표
+- `poll_song`: 투표 곡 제안
+- `promo`: 홍보글
+- `promo_photo`: 홍보글 사진
+- `promo_comment`: 홍보글 댓글
+- `team`: 팀
+- `team_event`: 팀 이벤트
+- `promo_report`: 홍보글 신고
+- `promo_comment_report`: 댓글 신고
+
+#### **그룹 3: 사용자 고유 행위 (즉시 하드 삭제 + 카운트 조정)**
+유니크 제약이 있는 데이터는 즉시 DELETE 처리하고 연관 카운트 조정
+
+**대상 테이블:**
+- `vote`: 투표 행위 삭제 (카운트 조정 불필요, 실시간 연산)
+- `promo_like`: 홍보글 좋아요 삭제 + promo.like_count - 1
+- `promo_comment_like`: 댓글 좋아요 삭제 (카운트 조정 불필요, 실시간 연산)
+
+### 처리 결과 로깅
+- 각 그룹별 레코드 정리 작업 로깅
+- 전체 처리 과정의 성공/실패 상태 기록
+
+### 탈퇴 후 제약 사항
+- 탈퇴 후 7일간 재로그인 제한 (deleted_at 기반 체크)
+- 익명화된 콘텐츠(user_id: -1)는 "(탈퇴한 계정)"으로 표시
+- 7일 후 cronjob에 의한 개인 종속 데이터 완전 삭제 예정
+- 투표 집계는 실시간 연산으로 처리되어 별도 카운트 조정 불필요
 
 ### 실패 응답
 - **400**: 동아리 대표자는 탈퇴 불가 (먼저 대표자 권한 위임 필요)

--- a/src/main/java/com/jandi/band_backend/club/repository/ClubEventRepository.java
+++ b/src/main/java/com/jandi/band_backend/club/repository/ClubEventRepository.java
@@ -2,6 +2,7 @@ package com.jandi.band_backend.club.repository;
 
 import com.jandi.band_backend.club.entity.ClubEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -25,4 +26,8 @@ public interface ClubEventRepository extends JpaRepository<ClubEvent, Long> {
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    @Modifying
+    @Query(value = "UPDATE club_event SET creator_user_id = -1 WHERE creator_user_id = :userId", nativeQuery = true)
+    int anonymizeByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/club/repository/ClubGalPhotoRepository.java
+++ b/src/main/java/com/jandi/band_backend/club/repository/ClubGalPhotoRepository.java
@@ -5,6 +5,7 @@ import com.jandi.band_backend.club.entity.ClubGalPhoto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -25,4 +26,8 @@ public interface ClubGalPhotoRepository extends JpaRepository<ClubGalPhoto, Inte
     Page<ClubGalPhoto> findByClubIdAndDeletedAtIsNullFetchUploader(@Param("clubId") Integer clubId, Pageable pageable);
 
     Optional<ClubGalPhoto> findByIdAndClubAndDeletedAtIsNull(Integer id, Club club);
+
+    @Modifying
+    @Query(value = "UPDATE club_gal_photo SET uploader_user_id = -1 WHERE uploader_user_id = :userId", nativeQuery = true)
+    int anonymizeByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/club/repository/ClubMemberRepository.java
+++ b/src/main/java/com/jandi/band_backend/club/repository/ClubMemberRepository.java
@@ -4,10 +4,12 @@ import com.jandi.band_backend.club.entity.Club;
 import com.jandi.band_backend.club.entity.ClubMember;
 import com.jandi.band_backend.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,4 +39,8 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Integer>
     Integer user(Users user);
 
     Boolean existsByUserIdAndClub_IdAndDeletedAtIsNullAndRole(Integer userId, Integer clubId, ClubMember.MemberRole memberRole);
+
+    @Modifying
+    @Query("UPDATE ClubMember cm SET cm.deletedAt = :deletedAt WHERE cm.user.id = :userId AND cm.deletedAt IS NULL")
+    int softDeleteByUserId(@Param("userId") Integer userId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/com/jandi/band_backend/poll/repository/PollRepository.java
+++ b/src/main/java/com/jandi/band_backend/poll/repository/PollRepository.java
@@ -5,6 +5,9 @@ import com.jandi.band_backend.poll.entity.Poll;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -18,4 +21,8 @@ public interface PollRepository extends JpaRepository<Poll, Integer> {
     Page<Poll> findAllByClubAndEndDatetimeAfterAndDeletedAtIsNullOrderByEndDatetimeAsc(Club club, LocalDateTime now, Pageable pageable);
 
     Optional<Poll> findByIdAndDeletedAtIsNull(Integer id);
+
+    @Modifying
+    @Query(value = "UPDATE poll SET creator_user_id = -1 WHERE creator_user_id = :userId", nativeQuery = true)
+    int anonymizeByCreatorId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/poll/repository/PollSongRepository.java
+++ b/src/main/java/com/jandi/band_backend/poll/repository/PollSongRepository.java
@@ -3,6 +3,9 @@ package com.jandi.band_backend.poll.repository;
 import com.jandi.band_backend.poll.entity.Poll;
 import com.jandi.band_backend.poll.entity.PollSong;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +13,8 @@ import java.util.List;
 @Repository
 public interface PollSongRepository extends JpaRepository<PollSong, Integer> {
     List<PollSong> findAllByPollAndDeletedAtIsNullOrderByCreatedAtDesc(Poll poll);
+
+    @Modifying
+    @Query(value = "UPDATE poll_song SET suggester_user_id = -1 WHERE suggester_user_id = :userId", nativeQuery = true)
+    int anonymizeBySuggesterId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/poll/repository/VoteRepository.java
+++ b/src/main/java/com/jandi/band_backend/poll/repository/VoteRepository.java
@@ -3,6 +3,9 @@ package com.jandi.band_backend.poll.repository;
 import com.jandi.band_backend.poll.entity.Vote;
 import com.jandi.band_backend.poll.entity.Vote.VotedMark;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +15,8 @@ import java.util.Optional;
 public interface VoteRepository extends JpaRepository<Vote, Integer> {
     Optional<Vote> findByPollSongIdAndUserIdAndVotedMark(Integer pollSongId, Integer userId, VotedMark votedMark);
     List<Vote> findByPollSongIdAndUserId(Integer pollSongId, Integer userId);
+
+    @Modifying
+    @Query("DELETE FROM Vote v WHERE v.user.id = :userId")
+    int deleteByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/promo/entity/PromoCommentReport.java
+++ b/src/main/java/com/jandi/band_backend/promo/entity/PromoCommentReport.java
@@ -10,9 +10,7 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "promo_comment_report", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"promo_comment_id", "reporter_user_id"})
-})
+@Table(name = "promo_comment_report")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/jandi/band_backend/promo/entity/PromoReport.java
+++ b/src/main/java/com/jandi/band_backend/promo/entity/PromoReport.java
@@ -10,9 +10,7 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "promo_report", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"promo_id", "reporter_user_id"})
-})
+@Table(name = "promo_report")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoCommentLikeRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoCommentLikeRepository.java
@@ -4,6 +4,7 @@ import com.jandi.band_backend.promo.entity.PromoComment;
 import com.jandi.band_backend.promo.entity.PromoCommentLike;
 import com.jandi.band_backend.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -20,4 +21,8 @@ public interface PromoCommentLikeRepository extends JpaRepository<PromoCommentLi
     Integer countByPromoComment(@Param("promoComment") PromoComment promoComment);
     
     boolean existsByPromoCommentAndUser(PromoComment promoComment, Users user);
-} 
+
+    @Modifying
+    @Query("DELETE FROM PromoCommentLike pcl WHERE pcl.user.id = :userId")
+    int deleteByUserId(@Param("userId") Integer userId);
+}

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoCommentReportRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoCommentReportRepository.java
@@ -2,8 +2,15 @@ package com.jandi.band_backend.promo.repository;
 
 import com.jandi.band_backend.promo.entity.PromoCommentReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PromoCommentReportRepository extends JpaRepository<PromoCommentReport, Integer> {
+
+    @Modifying
+    @Query(value = "UPDATE promo_comment_report SET reporter_user_id = -1 WHERE reporter_user_id = :userId", nativeQuery = true)
+    int anonymizeByReporterId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoCommentRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoCommentRepository.java
@@ -5,6 +5,7 @@ import com.jandi.band_backend.promo.entity.PromoComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -22,4 +23,8 @@ public interface PromoCommentRepository extends JpaRepository<PromoComment, Inte
     
     @Query("SELECT COUNT(pc) FROM PromoComment pc WHERE pc.deletedAt IS NULL AND pc.promo = :promo")
     Integer countByPromoAndNotDeleted(@Param("promo") Promo promo);
-} 
+
+    @Modifying
+    @Query(value = "UPDATE promo_comment SET creator_user_id = -1 WHERE creator_user_id = :userId", nativeQuery = true)
+    int anonymizeByUserId(@Param("userId") Integer userId);
+}

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoLikeRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoLikeRepository.java
@@ -4,20 +4,25 @@ import com.jandi.band_backend.promo.entity.Promo;
 import com.jandi.band_backend.promo.entity.PromoLike;
 import com.jandi.band_backend.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PromoLikeRepository extends JpaRepository<PromoLike, Integer> {
     
-    @Query("SELECT pl FROM PromoLike pl WHERE pl.promo = :promo AND pl.user = :user")
-    Optional<PromoLike> findByPromoAndUser(@Param("promo") Promo promo, @Param("user") Users user);
-    
-    @Query("SELECT COUNT(pl) FROM PromoLike pl WHERE pl.promo = :promo")
-    Integer countByPromo(@Param("promo") Promo promo);
+    Optional<PromoLike> findByPromoAndUser(Promo promo, Users user);
     
     boolean existsByPromoAndUser(Promo promo, Users user);
-} 
+
+    @Query("SELECT pl.promo.id FROM PromoLike pl WHERE pl.user.id = :userId")
+    List<Integer> findPromoIdsByUserId(@Param("userId") Integer userId);
+
+    @Modifying
+    @Query("DELETE FROM PromoLike pl WHERE pl.user.id = :userId")
+    int deleteByUserId(@Param("userId") Integer userId);
+}

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoPhotoRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoPhotoRepository.java
@@ -2,6 +2,7 @@ package com.jandi.band_backend.promo.repository;
 
 import com.jandi.band_backend.promo.entity.PromoPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,4 +20,8 @@ public interface PromoPhotoRepository extends JpaRepository<PromoPhoto, Integer>
     
     @Query("SELECT pp FROM PromoPhoto pp WHERE pp.promo.id = :promoId AND pp.imageUrl = :imageUrl AND pp.deletedAt IS NULL")
     PromoPhoto findByPromoIdAndImageUrlAndNotDeleted(@Param("promoId") Integer promoId, @Param("imageUrl") String imageUrl);
-} 
+
+    @Modifying
+    @Query(value = "UPDATE promo_photo SET uploader_user_id = -1 WHERE uploader_user_id = :userId", nativeQuery = true)
+    int anonymizeByUserId(@Param("userId") Integer userId);
+}

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoReportRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoReportRepository.java
@@ -2,8 +2,15 @@ package com.jandi.band_backend.promo.repository;
 
 import com.jandi.band_backend.promo.entity.PromoReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PromoReportRepository extends JpaRepository<PromoReport, Integer> {
+
+    @Modifying
+    @Query(value = "UPDATE promo_report SET reporter_user_id = -1 WHERE reporter_user_id = :userId", nativeQuery = true)
+    int anonymizeByReporterId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/promo/repository/PromoRepository.java
+++ b/src/main/java/com/jandi/band_backend/promo/repository/PromoRepository.java
@@ -4,6 +4,7 @@ import com.jandi.band_backend.promo.entity.Promo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -73,4 +74,12 @@ public interface PromoRepository extends JpaRepository<Promo, Integer> {
             @Param("maxLng") BigDecimal maxLng,
             Pageable pageable
     );
-} 
+
+    @Modifying
+    @Query(value = "UPDATE promo SET creator_user_id = -1 WHERE creator_user_id = :userId", nativeQuery = true)
+    int anonymizeByCreatorId(@Param("userId") Integer userId);
+
+    @Modifying
+    @Query("UPDATE Promo p SET p.likeCount = p.likeCount - 1 WHERE p.id = :promoId AND p.likeCount > 0")
+    void decrementLikeCount(@Param("promoId") Integer promoId);
+}

--- a/src/main/java/com/jandi/band_backend/team/repository/TeamEventRepository.java
+++ b/src/main/java/com/jandi/band_backend/team/repository/TeamEventRepository.java
@@ -4,6 +4,7 @@ import com.jandi.band_backend.team.entity.TeamEvent;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -35,4 +36,8 @@ public interface TeamEventRepository extends JpaRepository<TeamEvent, Integer> {
     List<TeamEvent> findTeamEventsByTeamIdAndDateRange(@Param("teamId") Integer teamId, 
                                                        @Param("startDate") LocalDateTime startDate, 
                                                        @Param("endDate") LocalDateTime endDate);
+
+    @Modifying
+    @Query(value = "UPDATE team_event SET creator_user_id = -1 WHERE creator_user_id = :userId", nativeQuery = true)
+    int anonymizeByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/jandi/band_backend/team/repository/TeamMemberRepository.java
@@ -2,8 +2,12 @@ package com.jandi.band_backend.team.repository;
 
 import com.jandi.band_backend.team.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +21,8 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Integer>
     Integer countByTeamIdAndDeletedAtIsNull(Integer teamId);
     // 팀 ID와 사용자 ID로 멤버 조회
     Optional<TeamMember> findByTeamIdAndUserIdAndDeletedAtIsNull(Integer teamId, Integer userId);
+
+    @Modifying
+    @Query("UPDATE TeamMember tm SET tm.deletedAt = :deletedAt WHERE tm.user.id = :userId AND tm.deletedAt IS NULL")
+    int softDeleteByUserId(@Param("userId") Integer userId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/com/jandi/band_backend/team/repository/TeamRepository.java
+++ b/src/main/java/com/jandi/band_backend/team/repository/TeamRepository.java
@@ -5,6 +5,9 @@ import com.jandi.band_backend.team.entity.Team;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,4 +18,8 @@ public interface TeamRepository extends JpaRepository<Team, Integer> {
     Optional<Team> findByIdAndDeletedAtIsNull(Integer id);
     Page<Team> findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(Club club, Pageable pageable);
     List<Team> findAllByClubIdAndDeletedAtIsNull(Integer clubId);
+
+    @Modifying
+    @Query(value = "UPDATE team SET creator_user_id = -1 WHERE creator_user_id = :userId", nativeQuery = true)
+    int anonymizeByCreatorId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/jandi/band_backend/user/repository/UserPhotoRepository.java
+++ b/src/main/java/com/jandi/band_backend/user/repository/UserPhotoRepository.java
@@ -3,9 +3,17 @@ package com.jandi.band_backend.user.repository;
 import com.jandi.band_backend.user.entity.UserPhoto;
 import com.jandi.band_backend.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserPhotoRepository extends JpaRepository<UserPhoto, Long> {
     UserPhoto findByUser(Users user);
+
+    @Modifying
+    @Query("UPDATE UserPhoto up SET up.deletedAt = :deletedAt WHERE up.user.id = :userId AND up.deletedAt IS NULL")
+    int softDeleteByUserId(@Param("userId") Integer userId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/com/jandi/band_backend/user/repository/UserTimetableRepository.java
+++ b/src/main/java/com/jandi/band_backend/user/repository/UserTimetableRepository.java
@@ -3,10 +3,12 @@ package com.jandi.band_backend.user.repository;
 import com.jandi.band_backend.user.entity.UserTimetable;
 import com.jandi.band_backend.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,4 +20,8 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, In
 
     @Query("SELECT ut FROM UserTimetable ut JOIN FETCH ut.user WHERE ut.id = :timetableId AND ut.deletedAt IS NULL")
     Optional<UserTimetable> findByIdWithUserAndDeletedAtIsNull(@Param("timetableId") Integer timetableId);
+
+    @Modifying
+    @Query("UPDATE UserTimetable ut SET ut.deletedAt = :deletedAt WHERE ut.user.id = :userId AND ut.deletedAt IS NULL")
+    int softDeleteByUserId(@Param("userId") Integer userId, @Param("deletedAt") LocalDateTime deletedAt);
 }


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 제곧내

## **✅ 변경 사항**

- 커밋 참조

## **📸 스크린샷 (선택)**

## **💬 코멘트**

### 회원탈퇴 서비스 코드 전략

그룹 1: 개인 종속 데이터 (소프트 삭제 → 하드 삭제)
* 대상: users, user_photo, user_timetable, club_member, team_member
* 처리: 탈퇴 시 소프트 삭제(deleted_at 설정) → 7일 후 하드삭제 (cronjob, 추후 구현 예정)

그룹 2: 콘텐츠 소유권 (데이터는 남기되 익명화: 탈퇴한 계정인 user_id: -1로 수정)
* 대상: club_gal_photo, club_event, poll, poll_song, promo, promo_photo, promo_comment, team, team_event, promo_report, promo_comment_report
* 처리: 탈퇴 시 즉시 user_id 관련 필드를 -1로 업데이트

그룹 3: 사용자의 고유 행위 (즉시 하드 삭제 및 카운트 조정)    // 유니크 제약
* 대상:
    * vote (투표 행위)
    * promo_like (좋아요 행위)
    * promo_comment_like (댓글 좋아요 행위)
* 처리: 탈퇴 시 즉시 해당 레코드를 삭제(DELETE) 하고, 필요한 경우 연관된 카운트를 조정
