### PR TITLE
fix: 삭제 뒤 카운트를 추가로 -1하여 표시되는 버그 수정

### DIFF
--- a/src/main/java/com/jandi/band_backend/poll/entity/Vote.java
+++ b/src/main/java/com/jandi/band_backend/poll/entity/Vote.java
@@ -9,7 +9,9 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "vote")
+@Table(name = "vote", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"poll_song_id", "user_id"})
+})
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/jandi/band_backend/poll/service/PollService.java
+++ b/src/main/java/com/jandi/band_backend/poll/service/PollService.java
@@ -170,13 +170,6 @@ public class PollService {
         int cantCount = calculateVoteCount(pollSong, "CANT");
         int hajjCount = calculateVoteCount(pollSong, "HAJJ");
 
-        switch (voteType.toUpperCase()) {
-            case "LIKE", "좋아요" -> likeCount -= 1;
-            case "DISLIKE", "별로에요" -> dislikeCount -= 1;
-            case "CANT", "실력부족" -> cantCount -= 1;
-            case "HAJJ", "하고싶지_않은데_존중해요" -> hajjCount -= 1;
-        }
-
         String suggesterProfilePhoto = pollSong.getSuggester().getPhotos().stream()
                 .filter(photo -> photo.getIsCurrent() && photo.getDeletedAt() == null)
                 .map(photo -> photo.getImageUrl())


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 제곧내

## **✅ 변경 사항**

- 커밋 참조

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 삭제 뒤 카운트를 추가로 -1하여 표시되는 버그 수정
- DB와 같이 투표 엔티티에 유니크 제약 걸었고, 이에 걸맞게 1인 1투표 서비스 로직을 간소화함