### PR TITLE
fix: 초대 링크 대신 코드를 주는 것으로 수정

### DIFF
--- a/src/main/java/com/jandi/band_backend/invite/dto/InviteLinkRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/invite/dto/InviteLinkRespDTO.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class InviteLinkRespDTO {
-    private final String link;
+    private final String code;
 }

--- a/src/main/java/com/jandi/band_backend/invite/service/InviteService.java
+++ b/src/main/java/com/jandi/band_backend/invite/service/InviteService.java
@@ -6,7 +6,6 @@ import com.jandi.band_backend.invite.redis.InviteCodeService;
 import com.jandi.band_backend.invite.redis.InviteType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;

--- a/src/main/java/com/jandi/band_backend/invite/service/InviteService.java
+++ b/src/main/java/com/jandi/band_backend/invite/service/InviteService.java
@@ -18,9 +18,6 @@ public class InviteService {
     private final InviteUtilService inviteUtilService;
     private static final Random RANDOM = new Random();
 
-    @Value("${invite.club.link.prefix}") private String clubLinkPrefix;
-    @Value("${invite.team.link.prefix}") private String teamLinkPrefix;
-
     @Transactional
     public InviteLinkRespDTO generateInviteClubLink(Integer clubId, Integer userId) {
         inviteUtilService.isExistClub(clubId);
@@ -31,9 +28,7 @@ public class InviteService {
         // code 생성 후 Redis 서버에 저장
         String code = generateRandomCode();
         inviteCodeService.saveCode(InviteType.CLUB, clubId, code);
-
-        String link = clubLinkPrefix + "?code=" + code;
-        return new InviteLinkRespDTO(link);
+        return new InviteLinkRespDTO(code);
     }
 
     @Transactional
@@ -46,9 +41,7 @@ public class InviteService {
         // code 생성 후 Redis 서버에 저장
         String code = generateRandomCode();
         inviteCodeService.saveCode(InviteType.TEAM, teamId, code);
-
-        String link = teamLinkPrefix + "?code=" + code;
-        return new InviteLinkRespDTO(link);
+        return new InviteLinkRespDTO(code);
     }
 
     private String generateRandomCode() {


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #이슈번호

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 어떤 작업을 했는지 간단히 설명해주세요.

## **✅ 변경 사항**

- 초대 링크 보내줄 때 link 대신 code를 넘겨주도록 InviteLinkRespDTO 수정
- 초대링크를 변수화할 필요가 없어짐에 따라 환경변수파일에서 `invite.club.link.prefix`, `invite.team.link.prefix` 이건 지워도 될거같습니다

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 리뷰 시 참고하거나 봐줬으면 하는 부분이 있다면 작성해주세요.
