### PR TITLE
feat: 공지사항 수정 API를 PUT에서 PATCH로 재작성

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,16 +2,11 @@ pipeline {
     agent any
 
     environment {
-        // 공통 변수
         GHCR_OWNER = 'kyj0503'
-        
-        // 운영(Production) 환경 변수
         PROD_IMAGE_NAME = 'rhythmeet-be'
+        DEV_IMAGE_NAME = 'rhythmeet-be-dev'
         EC2_HOST = 'rhythmeet.yeonjae.kr'
         EC2_USER = 'ubuntu'
-
-        // 개발(Development) 환경 변수
-        DEV_IMAGE_NAME = 'rhythmeet-be-dev'
     }
 
     stages {
@@ -21,50 +16,65 @@ pipeline {
             }
         }
 
-        stage('Build and Push to GHCR') {
+        // --- Master 브랜치 전용 스테이지 ---
+        stage('Build and Push PROD Image') {
+            when { branch 'master' }
             steps {
                 script {
-                    def imageName = (env.BRANCH_NAME == 'master') ? env.PROD_IMAGE_NAME : env.DEV_IMAGE_NAME
-                    def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.IMAGE_NAME}:${env.BUILD_NUMBER}"
-
-                    echo "Building Docker image: ${fullImageName}"
+                    // 변수를 이 단계에서 명확하게 정의
+                    def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.PROD_IMAGE_NAME}:${env.BUILD_NUMBER}"
+                    echo "Building PROD image for master branch: ${fullImageName}"
+                    
                     docker.build(fullImageName, '.')
-
                     docker.withRegistry("https://ghcr.io", 'github-token') {
-                        echo "Pushing Docker image to GHCR..."
+                        echo "Pushing PROD image to GHCR..."
                         docker.image(fullImageName).push()
                     }
                 }
             }
         }
 
-        stage('Deploy') {
-            parallel {
-                stage('Deploy to Production (EC2)') {
-                    when { branch 'master' } // 이 스테이지는 master 브랜치일 때만 실행
-                    steps {
-                        script {
-                            def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.PROD_IMAGE_NAME}:${env.BUILD_NUMBER}"
-                            withCredentials([sshUserPrivateKey(credentialsId: 'ec2-ssh-key', keyFileVariable: 'EC2_PRIVATE_KEY')]) {
-                                echo "Deploying to EC2 host: ${env.EC2_HOST}"
-                                sh """
-                                    ssh -o StrictHostKeyChecking=no -i \${EC2_PRIVATE_KEY} ${env.EC2_USER}@${env.EC2_HOST} \
-                                    "bash /home/ubuntu/spring-app/deploy.sh ${fullImageName}"
-                                """
-                            }
-                        }
+        stage('Deploy to Production (EC2)') {
+            when { branch 'master' }
+            steps {
+                script {
+                    // 배포할 이미지 이름을 다시 명확하게 정의
+                    def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.PROD_IMAGE_NAME}:${env.BUILD_NUMBER}"
+                    withCredentials([sshUserPrivateKey(credentialsId: 'ec2-ssh-key', keyFileVariable: 'EC2_PRIVATE_KEY')]) {
+                        echo "Deploying to EC2 host: ${env.EC2_HOST}"
+                        sh """
+                            ssh -o StrictHostKeyChecking=no -i \${EC2_PRIVATE_KEY} ${env.EC2_USER}@${env.EC2_HOST} \
+                            "bash /home/ubuntu/spring-app/deploy.sh ${fullImageName}"
+                        """
                     }
                 }
+            }
+        }
 
-                stage('Deploy to Development (Local)') {
-                    when { branch 'dev' } // 이 스테이지는 dev 브랜치일 때만 실행
-                    steps {
-                        script {
-                            def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.DEV_IMAGE_NAME}:${env.BUILD_NUMBER}"
-                            echo "Deploying to local on-premise server"
-                            sh "bash /home/kyj/spring-app-dev/deploy.sh ${fullImageName}"
-                        }
+        // --- Dev 브랜치 전용 스테이지 ---
+        stage('Build and Push DEV Image') {
+            when { branch 'dev' }
+            steps {
+                script {
+                    def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.DEV_IMAGE_NAME}:${env.BUILD_NUMBER}"
+                    echo "Building DEV image for dev branch: ${fullImageName}"
+
+                    docker.build(fullImageName, '.')
+                    docker.withRegistry("https://ghcr.io", 'github-token') {
+                        echo "Pushing DEV image to GHCR..."
+                        docker.image(fullImageName).push()
                     }
+                }
+            }
+        }
+
+        stage('Deploy to Development (Local)') {
+            when { branch 'dev' }
+            steps {
+                script {
+                    def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.DEV_IMAGE_NAME}:${env.BUILD_NUMBER}"
+                    echo "Deploying to local on-premise server"
+                    sh "bash /home/kyj/spring-app-dev/deploy.sh ${fullImageName}"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
                 script {
                     def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.DEV_IMAGE_NAME}:${env.BUILD_NUMBER}"
                     echo "Deploying to local on-premise server"
-                    sh "bash /home/kyj/spring-app-dev/deploy.sh ${fullImageName}"
+                    sh "bash /opt/spring-app-dev/deploy.sh ${fullImageName}"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,16 @@ pipeline {
     agent any
 
     environment {
+        // 공통 변수
         GHCR_OWNER = 'kyj0503'
+        
+        // 운영(Production) 환경 변수
+        PROD_IMAGE_NAME = 'rhythmeet-be'
         EC2_HOST = 'rhythmeet.yeonjae.kr'
         EC2_USER = 'ubuntu'
-        IMAGE_NAME = 'rhythmeet-be'
+
+        // 개발(Development) 환경 변수
+        DEV_IMAGE_NAME = 'rhythmeet-be-dev'
     }
 
     stages {
@@ -18,6 +24,7 @@ pipeline {
         stage('Build and Push to GHCR') {
             steps {
                 script {
+                    def imageName = (env.BRANCH_NAME == 'master') ? env.PROD_IMAGE_NAME : env.DEV_IMAGE_NAME
                     def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.IMAGE_NAME}:${env.BUILD_NUMBER}"
 
                     echo "Building Docker image: ${fullImageName}"
@@ -31,18 +38,32 @@ pipeline {
             }
         }
 
-        stage('Deploy to EC2') {
-            steps {
-                script {
-                    def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.IMAGE_NAME}:${env.BUILD_NUMBER}"
+        stage('Deploy') {
+            parallel {
+                stage('Deploy to Production (EC2)') {
+                    when { branch 'master' } // 이 스테이지는 master 브랜치일 때만 실행
+                    steps {
+                        script {
+                            def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.PROD_IMAGE_NAME}:${env.BUILD_NUMBER}"
+                            withCredentials([sshUserPrivateKey(credentialsId: 'ec2-ssh-key', keyFileVariable: 'EC2_PRIVATE_KEY')]) {
+                                echo "Deploying to EC2 host: ${env.EC2_HOST}"
+                                sh """
+                                    ssh -o StrictHostKeyChecking=no -i \${EC2_PRIVATE_KEY} ${env.EC2_USER}@${env.EC2_HOST} \
+                                    "bash /home/ubuntu/spring-app/deploy.sh ${fullImageName}"
+                                """
+                            }
+                        }
+                    }
+                }
 
-                    withCredentials([sshUserPrivateKey(credentialsId: 'ec2-ssh-key', keyFileVariable: 'EC2_PRIVATE_KEY')]) {
-                        echo "Deploying to EC2 host: ${env.EC2_HOST}"
-                        // EC2의 spring-app 디렉터리에 있는 배포 스크립트 실행
-                        sh """
-                            ssh -o StrictHostKeyChecking=no -i \${EC2_PRIVATE_KEY} ${env.EC2_USER}@${env.EC2_HOST} \
-                            "bash /home/ubuntu/spring-app/deploy.sh ${fullImageName}"
-                        """
+                stage('Deploy to Development (Local)') {
+                    when { branch 'dev' } // 이 스테이지는 dev 브랜치일 때만 실행
+                    steps {
+                        script {
+                            def fullImageName = "ghcr.io/${env.GHCR_OWNER}/${env.DEV_IMAGE_NAME}:${env.BUILD_NUMBER}"
+                            echo "Deploying to local on-premise server"
+                            sh "bash /home/kyj/spring-app-dev/deploy.sh ${fullImageName}"
+                        }
                     }
                 }
             }

--- a/docs/notice-notice.md
+++ b/docs/notice-notice.md
@@ -203,7 +203,7 @@ curl -X POST "http://localhost:8080/api/notices" \
 
 ## 5. 공지사항 수정 (관리자 전용)
 ```
-PUT /api/notices/{noticeId}
+PATCH /api/notices/{noticeId}
 Authorization: Bearer {JWT_TOKEN}
 Content-Type: multipart/form-data
 ```
@@ -212,13 +212,26 @@ Content-Type: multipart/form-data
 
 ### 요청 예시
 ```bash
-curl -X PUT "http://localhost:8080/api/notices/1" \
+# 제목과 내용만 수정
+curl -X PATCH "http://localhost:8080/api/notices/1" \
   -H "Authorization: Bearer {JWT_TOKEN}" \
   -F "title=수정된 점검 안내" \
-  -F "content=수정된 내용입니다." \
-  -F "startDatetime=2024-12-10T00:00:00" \
-  -F "endDatetime=2024-12-10T23:59:59" \
+  -F "content=수정된 내용입니다."
+
+# 이미지만 변경
+curl -X PATCH "http://localhost:8080/api/notices/1" \
+  -H "Authorization: Bearer {JWT_TOKEN}" \
   -F "image=@/path/to/new-image.jpg"
+
+# 시작/종료 시각만 변경
+curl -X PATCH "http://localhost:8080/api/notices/1" \
+  -H "Authorization: Bearer {JWT_TOKEN}" \
+  -F "endDatetime=2024-12-11T23:59:59"
+
+# 이미지 삭제
+curl -X PATCH "http://localhost:8080/api/notices/1" \
+  -H "Authorization: Bearer {JWT_TOKEN}" \
+  -F "deleteImage=true"
 ```
 
 ### 성공 응답 (200)
@@ -243,24 +256,34 @@ curl -X PUT "http://localhost:8080/api/notices/1" \
 }
 ```
 
-### 요청 필드
-- `title` (string, 필수): 공지사항 제목 (최대 255자)
-- `content` (string, 필수): 공지사항 내용
-- `startDatetime` (datetime, 필수): 팝업 노출 시작 시각
-- `endDatetime` (datetime, 필수): 팝업 노출 종료 시각
-- `image` (file, 선택): 첨부 이미지 파일
+### 요청 필드 (모두 선택적)
+- `title` (string, 선택): 공지사항 제목 (최대 255자)
+- `content` (string, 선택): 공지사항 내용
+- `startDatetime` (datetime, 선택): 팝업 노출 시작 시각
+- `endDatetime` (datetime, 선택): 팝업 노출 종료 시각
+- `image` (file, 선택): 새로운 첨부 이미지 파일
+- `deleteImage` (boolean, 선택): 이미지 삭제 여부 (true로 설정 시 기존 이미지 삭제)
+
+### 부분 수정 특징
+- **모든 필드가 선택적입니다** - 변경하고 싶은 필드만 포함하여 요청
+- 포함되지 않은 필드는 기존 값이 유지됩니다
+- 빈 문자열이나 null 값으로 필드를 비울 수 없습니다 (제목의 경우 빈 문자열 전송 시 에러)
 
 ### 실패 응답
-- **400**: 필수 필드 누락 또는 종료 시각이 시작 시각보다 이른 경우
+- **400**:
+  - 빈 제목 (공백만 있는 경우)
+  - 종료 시각이 시작 시각보다 이른 경우
+  - 이미지 파일 크기가 10MB 초과
+  - 이미지가 아닌 파일 업로드
 - **403**: 관리자 권한 없음
 - **404**: 존재하지 않는 공지사항
 
-### 이미지 수정 참고사항
-- **일시정지 상태(`isPaused`)는 수정되지 않습니다**
-- 일시정지 상태를 변경하려면 별도의 토글 API(`PATCH /api/notices/{noticeId}/toggle-pause`)를 사용하세요
-- 새 이미지를 업로드하면 기존 이미지는 S3에서 자동으로 삭제됩니다
-- `image` 필드를 생략하면 기존 이미지가 유지됩니다
-- 이미지를 완전히 제거할 수는 없으며, 새 이미지로만 교체 가능합니다
+### 이미지 처리 참고사항
+- **이미지 삭제**: `deleteImage=true`로 설정하여 기존 이미지 제거 가능
+- **이미지 교체**: 새 이미지 파일을 전송하면 기존 이미지는 자동 삭제
+- **동시 요청 시**: `deleteImage=true`와 새 이미지를 동시에 보내면 새 이미지 업로드가 우선
+- **일시정지 상태(`isPaused`)는 수정되지 않습니다** - 별도의 토글 API 사용
+- 이미지 크기는 10MB로 제한되며, 이미지 파일만 업로드 가능
 
 ---
 
@@ -436,7 +459,7 @@ curl -X PATCH "http://localhost:8080/api/notices/1/toggle-pause" \
 **사용 API:**
 - `GET /api/notices/{noticeId}` (공지사항 상세 조회)
 - `POST /api/notices` (공지사항 생성)
-- `PUT /api/notices/{noticeId}` (공지사항 수정)
+- `PATCH /api/notices/{noticeId}` (공지사항 수정)
 
 ---
 

--- a/src/main/java/com/jandi/band_backend/notice/controller/NoticeController.java
+++ b/src/main/java/com/jandi/band_backend/notice/controller/NoticeController.java
@@ -3,6 +3,7 @@ package com.jandi.band_backend.notice.controller;
 import com.jandi.band_backend.global.dto.CommonRespDTO;
 import com.jandi.band_backend.global.dto.PagedRespDTO;
 import com.jandi.band_backend.notice.dto.NoticeReqDTO;
+import com.jandi.band_backend.notice.dto.NoticeUpdateReqDTO;
 import com.jandi.band_backend.notice.dto.NoticeDetailRespDTO;
 import com.jandi.band_backend.notice.dto.NoticeRespDTO;
 import com.jandi.band_backend.notice.service.NoticeService;
@@ -69,10 +70,10 @@ public class NoticeController {
     }
 
     @Operation(summary = "공지사항 수정 (관리자 전용)")
-    @PutMapping("/{noticeId}")
+    @PatchMapping("/{noticeId}")
     public ResponseEntity<CommonRespDTO<NoticeDetailRespDTO>> updateNotice(
             @PathVariable Integer noticeId,
-            @Valid @ModelAttribute NoticeReqDTO request,
+            @Valid @ModelAttribute NoticeUpdateReqDTO request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Integer userId = userDetails.getUserId();
         NoticeDetailRespDTO response = noticeService.updateNotice(noticeId, request, userId);

--- a/src/main/java/com/jandi/band_backend/notice/dto/NoticeReqDTO.java
+++ b/src/main/java/com/jandi/band_backend/notice/dto/NoticeReqDTO.java
@@ -22,8 +22,7 @@ public class NoticeReqDTO {
     @Size(max = 255, message = "제목은 255자를 초과할 수 없습니다")
     private String title;
 
-    @Schema(description = "공지사항 내용", example = "오늘 밤 12시부터 새벽 2시까지 사이트 점검이 있습니다.", required = true)
-    @NotBlank(message = "내용은 필수입니다")
+    @Schema(description = "공지사항 내용", example = "오늘 밤 12시부터 새벽 2시까지 사이트 점검이 있습니다.", required = false)
     private String content;
 
     @Schema(description = "팝업 노출 시작 시각", example = "2024-12-10T00:00:00", required = true)

--- a/src/main/java/com/jandi/band_backend/notice/dto/NoticeUpdateReqDTO.java
+++ b/src/main/java/com/jandi/band_backend/notice/dto/NoticeUpdateReqDTO.java
@@ -1,0 +1,36 @@
+package com.jandi.band_backend.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "공지사항 부분 수정 요청 DTO - 모든 필드가 선택적")
+public class NoticeUpdateReqDTO {
+
+    @Schema(description = "공지사항 제목 (선택적)", example = "사이트 점검 안내", maxLength = 255)
+    @Size(max = 255, message = "제목은 255자를 초과할 수 없습니다")
+    private String title;
+
+    @Schema(description = "공지사항 내용 (선택적)", example = "오늘 밤 12시부터 새벽 2시까지 사이트 점검이 있습니다.")
+    private String content;
+
+    @Schema(description = "팝업 노출 시작 시각 (선택적)", example = "2024-12-10T00:00:00")
+    private LocalDateTime startDatetime;
+
+    @Schema(description = "팝업 노출 종료 시각 (선택적)", example = "2024-12-10T23:59:59")
+    private LocalDateTime endDatetime;
+
+    @Schema(description = "첨부 이미지 파일 (선택적)", required = false)
+    private MultipartFile image;
+
+    @Schema(description = "이미지 삭제 여부 (true로 설정 시 기존 이미지 삭제)", example = "false")
+    private Boolean deleteImage = false;
+}

--- a/src/main/java/com/jandi/band_backend/notice/dto/NoticeUpdateReqDTO.java
+++ b/src/main/java/com/jandi/band_backend/notice/dto/NoticeUpdateReqDTO.java
@@ -31,6 +31,6 @@ public class NoticeUpdateReqDTO {
     @Schema(description = "첨부 이미지 파일 (선택적)", required = false)
     private MultipartFile image;
 
-    @Schema(description = "이미지 삭제 여부 (true로 설정 시 기존 이미지 삭제)", example = "false")
-    private Boolean deleteImage = false;
+    @Schema(description = "이미지 삭제 여부 (true로 설정 시 기존 이미지 삭제)", example = "false", defaultValue = "null")
+    private Boolean deleteImage;
 }

--- a/src/main/java/com/jandi/band_backend/notice/entity/Notice.java
+++ b/src/main/java/com/jandi/band_backend/notice/entity/Notice.java
@@ -27,7 +27,7 @@ public class Notice {
     @Column(name = "title", nullable = false, length = 255)
     private String title;
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "start_datetime", nullable = false)


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

공지사항 시스템의 전반적인 개선 작업을 수행했습니다:
- 공지사항 수정 API의 HTTP 메서드를 PUT에서 PATCH로 변경하여 RESTful API 규칙에 맞게 개선
- 부분 수정 기능을 위한 전용 DTO(`NoticeUpdateReqDTO`) 추가로 모든 필드를 선택적으로 수정 가능

## **✅ 변경 사항**

### 1. API 엔드포인트 변경
- `PUT /api/notices/{noticeId}` → `PATCH /api/notices/{noticeId}`
- RESTful API 규칙에 따라 부분 수정은 PATCH 메서드 사용

### 2. 부분 수정 기능 구현
- `NoticeUpdateReqDTO` 추가 - 모든 필드가 선택적(Optional)
- 전송된 필드만 업데이트되고, 나머지는 기존 값 유지
- 이미지 삭제 기능 추가 (`deleteImage` 필드)

### 3. 공지사항 내용(content) 필드 선택적으로 변경
- NoticeReqDTO: @NotBlank 검증 제거
- Notice 엔티티: content 필드 nullable로 변경
- DB 스키마: content TEXT NULL 허용

### 4. 이미지 처리 로직 개선
- 이미지 삭제와 업로드 동시 요청 시 에러 발생하던 것을 제거
- 새 이미지가 있으면 deleteImage 플래그 무시하고 새 이미지로 교체
- 이미지 파일 크기 제한 (10MB)
- 이미지 파일 타입 검증 (image/* 타입만 허용)
- 보다 직관적인 API 동작

### 5. 에러 처리 개선
- 이미지 업로드 실패 시 트랜잭션 롤백 처리
- 사용자 친화적인 에러 메시지 제공

### 6. 코드 품질 개선
- 요청 DTO 변수명을 `reqDTO`에서 `request`로 통일 (프로젝트 컨벤션)
- S3 이미지 롤백 처리를 위한 헬퍼 메서드 추가

### 7. API 문서 업데이트
- PATCH 메서드 변경 사항 반영
- 부분 수정 사용 예시 추가
- 에러 응답 케이스 상세화

## **📸 스크린샷 (선택)**

해당 사항 없음

## **💬 코멘트**

### 주요 개선사항
1. **RESTful 규칙 준수**: PUT은 전체 리소스 교체, PATCH는 부분 수정에 적합
2. **유연한 수정 기능**: 원하는 필드만 선택적으로 수정 가능
3. **안정성 향상**: 이미지 업로드 실패 시 롤백, 입력값 검증 강화
4. **사용자 경험 개선**: 프론트엔드 관점에서 더 유연하고 사용하기 쉬운 API가 되도록 작성
5. **에러 방지**: deleteImage=true를 보내도 새 이미지가 있으면 교체가 우선시됨
6. **유연한 데이터 관리**: 과거 날짜 공지사항도 생성 가능하여 이전 공지사항을 복원하거나 관리하기 용이