### PR TITLE
revert: 권한 관련 변경사항 되돌리기 (40b6a72~e5790da)

### DIFF
--- a/docs/club-club.md
+++ b/docs/club-club.md
@@ -149,16 +149,11 @@ curl "http://localhost:8080/api/clubs/1"
 ## 4. 동아리 부원 명단 조회
 ```
 GET /api/clubs/{clubId}/members
-Authorization: Bearer {JWT_TOKEN}
 ```
-
-### 권한
-- **동아리 멤버만 조회 가능**
 
 ### 요청 예시
 ```bash
-curl "http://localhost:8080/api/clubs/1/members" \
-  -H "Authorization: Bearer {JWT_TOKEN}"
+curl "http://localhost:8080/api/clubs/1/members"
 ```
 
 ### 성공 응답 (200)
@@ -189,9 +184,6 @@ curl "http://localhost:8080/api/clubs/1/members" \
   }
 }
 ```
-
-### 실패 응답
-- **403**: 동아리 멤버가 아님
 
 ---
 

--- a/docs/club-clubevent.md
+++ b/docs/club-clubevent.md
@@ -8,9 +8,8 @@ JWT 인증 필요 (Spring Security + @AuthenticationPrincipal CustomUserDetails)
 
 ## 권한 관리
 - **조회**: 로그인한 모든 사용자
-- **생성**: 동아리 멤버만 가능
+- **생성**: 동아리 멤버만 가능 
 - **삭제**: 일정을 생성한 사용자, 동아리 운영자, 또는 ADMIN 권한 사용자
-- **캘린더 조회**: 로그인한 모든 사용자 (공개 API)
 
 ---
 
@@ -86,10 +85,8 @@ curl -X GET "http://localhost:8080/api/clubs/1/events/15" \
 ### GET `/api/clubs/{clubId}/calendar`
 
 #### 설명
-동아리의 모든 일정(동아리 일정 + 모든 하위 팀의 연습 일정)을 통합하여 조회합니다.
+동아리의 모든 일정(동아리 일정 + 모든 하위 팀의 연습 일정)을 통합하여 조회합니다. 
 이 API 하나로 모든 일정을 확인할 수 있으며, 프론트엔드에서 `eventType` 필드로 필터링이 가능합니다.
-
-**참고**: 이 API는 인증된 사용자라면 동아리 멤버가 아니어도 접근 가능합니다.
 
 #### 경로 파라미터
 - `clubId` (integer, 필수): 동아리 ID
@@ -217,7 +214,7 @@ curl -X DELETE "http://localhost:8080/api/clubs/1/events/15" \
   "errorCode": "FORBIDDEN"
 }
 ```
-**발생 케이스**:
+**발생 케이스**: 
 - 동아리 멤버가 아닌 사용자의 일정 생성 시도
 - 일정 삭제 시 생성자, 동아리 운영자, ADMIN이 아닌 경우
 

--- a/docs/club-clubgalphoto.md
+++ b/docs/club-clubgalphoto.md
@@ -7,9 +7,7 @@
 JWT 인증 필요 (Spring Security + @AuthenticationPrincipal CustomUserDetails)
 
 ## 권한 관리
-- **조회**:
-  - 목록 조회: 동아리 멤버가 아니어도 가능 (isPublic=true인 사진 포함)
-  - 상세 조회: 동아리 멤버가 아니어도 가능 (isPublic=true인 사진만)
+- **조회**: 동아리 멤버만 가능
 - **생성/수정/삭제**: 동아리 멤버만 가능
 - **핀 등록/해제**: 동아리 멤버만 가능
 
@@ -17,9 +15,6 @@ JWT 인증 필요 (Spring Security + @AuthenticationPrincipal CustomUserDetails)
 
 ## 1. 동아리 사진 목록 조회
 ### GET `/api/clubs/{clubId}/photo`
-
-#### 설명
-동아리의 갤러리 사진 목록을 조회합니다. 동아리 멤버가 아닌 경우에도 공개(isPublic=true) 사진은 조회할 수 있습니다.
 
 #### 경로 파라미터
 - `clubId` (integer, 필수): 동아리 ID
@@ -65,9 +60,6 @@ curl -X GET "http://localhost:8080/api/clubs/1/photo?page=0&size=5" \
 
 ## 2. 동아리 사진 상세 조회
 ### GET `/api/clubs/{clubId}/photo/{photoId}`
-
-#### 설명
-특정 갤러리 사진의 상세 정보를 조회합니다. 동아리 멤버가 아닌 경우에는 공개(isPublic=true) 사진만 조회할 수 있습니다.
 
 #### 경로 파라미터
 - `clubId` (integer, 필수): 동아리 ID
@@ -319,11 +311,11 @@ interface ClubGalPhotoRespDetailDTO {
 ---
 
 ## 참고 사항
-- **동아리 멤버십**: 조회는 공개 사진에 한해 모든 인증 사용자 가능, 생성/수정/삭제는 동아리 멤버만 가능
+- **동아리 멤버십**: 모든 API는 동아리 멤버만 접근 가능
 - **이미지 형식**: JPG, PNG 등 일반적인 이미지 형식 지원
 - **이미지 교체**: 수정 시 새 이미지 업로드하면 기존 이미지 자동 교체
 - **부분 수정**: PATCH 방식으로 필요한 필드만 전송하면 나머지는 기존 값 유지
 - **핀 기능**: 중요한 사진을 상단에 고정하는 기능 (토글 방식)
 - **공개 설정**: isPublic 필드로 사진의 공개/비공개 설정 가능
 - **소프트 삭제**: 삭제된 사진은 실제로는 숨김 처리되어 복구 가능
-- **권한 확인**: 사진 수정/삭제는 업로더 본인 또는 동아리 대표만 가능, 핀 등록/해제는 동아리 대표만 가능
+- **권한 확인**: 사진 수정/삭제는 업로더 본인 또는 동아리 대표만 가능, 핀 등록/해제는 동아리 대표만 가능 

--- a/docs/poll-poll.md
+++ b/docs/poll-poll.md
@@ -26,7 +26,7 @@ curl -X POST "http://localhost:8080/api/polls" \
 
 ### 요청 필드
 - `title`: 투표 제목
-- `clubId`: 동아리 ID
+- `clubId`: 동아리 ID  
 - `endDatetime`: 투표 마감 시간 (미래 시간)
 
 ### 성공 응답 (201)
@@ -59,9 +59,6 @@ curl -X POST "http://localhost:8080/api/polls" \
 GET /api/polls/clubs/{clubId}?page=0&size=5
 Authorization: Bearer {JWT_TOKEN}
 ```
-
-### 권한
-- **동아리 멤버만 조회 가능**
 
 ### 요청 예시
 ```bash
@@ -104,9 +101,6 @@ curl "http://localhost:8080/api/polls/clubs/1?page=0&size=5" \
 }
 ```
 
-### 실패 응답
-- **403**: 동아리 멤버가 아님
-
 ---
 
 ## 3. 투표 상세 조회
@@ -114,9 +108,6 @@ curl "http://localhost:8080/api/polls/clubs/1?page=0&size=5" \
 GET /api/polls/{pollId}
 Authorization: Bearer {JWT_TOKEN}
 ```
-
-### 권한
-- **해당 투표가 속한 동아리의 멤버만 조회 가능**
 
 ### 요청 예시
 ```bash
@@ -161,9 +152,6 @@ curl "http://localhost:8080/api/polls/1" \
   }
 }
 ```
-
-### 실패 응답
-- **403**: 동아리 멤버가 아님
 
 ---
 
@@ -226,9 +214,6 @@ GET /api/polls/{pollId}/songs?sortBy=LIKE&order=desc
 Authorization: Bearer {JWT_TOKEN}
 ```
 
-### 권한
-- **해당 투표가 속한 동아리의 멤버만 조회 가능**
-
 ### 요청 예시
 ```bash
 # 좋아요 많은 순 (기본값)
@@ -284,9 +269,6 @@ curl "http://localhost:8080/api/polls/1/songs?sortBy=DISLIKE&order=asc" \
   ]
 }
 ```
-
-### 실패 응답
-- **403**: 동아리 멤버가 아님
 
 ### 종합 점수 계산 방식
 ```

--- a/docs/team-team.md
+++ b/docs/team-team.md
@@ -98,9 +98,6 @@ curl -X POST "http://localhost:8080/api/clubs/1/teams" \
 ## 2. 동아리 팀 목록 조회
 ### GET `/api/clubs/{clubId}/teams`
 
-#### 권한
-- **동아리 멤버만 조회 가능**
-
 #### 요청
 ```bash
 curl -X GET "http://localhost:8080/api/clubs/1/teams?page=0&size=5" \
@@ -141,9 +138,6 @@ curl -X GET "http://localhost:8080/api/clubs/1/teams?page=0&size=5" \
   }
 }
 ```
-
-### 실패 응답
-- **403**: 동아리 멤버가 아님
 
 ---
 

--- a/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
+++ b/src/main/java/com/jandi/band_backend/club/controller/ClubController.java
@@ -62,11 +62,8 @@ public class ClubController {
 
     @Operation(summary = "동아리 부원 명단 조회")
     @GetMapping("/{clubId}/members")
-    public ResponseEntity<CommonRespDTO<ClubMembersRespDTO>> getClubMembers(
-            @PathVariable Integer clubId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Integer currentUserId = userDetails.getUserId();
-        ClubMembersRespDTO response = clubService.getClubMembers(clubId, currentUserId);
+    public ResponseEntity<CommonRespDTO<ClubMembersRespDTO>> getClubMembers(@PathVariable Integer clubId) {
+        ClubMembersRespDTO response = clubService.getClubMembers(clubId);
         return ResponseEntity.ok(CommonRespDTO.success("동아리 부원 명단 조회 성공", response));
     }
 

--- a/src/main/java/com/jandi/band_backend/club/service/ClubService.java
+++ b/src/main/java/com/jandi/band_backend/club/service/ClubService.java
@@ -131,14 +131,8 @@ public class ClubService {
     }
 
     @Transactional(readOnly = true)
-    public ClubMembersRespDTO getClubMembers(Integer clubId, Integer currentUserId) {
+    public ClubMembersRespDTO getClubMembers(Integer clubId) {
         Club club = entityValidationUtil.validateClubExists(clubId);
-
-        permissionValidationUtil.validateClubMemberAccess(
-                clubId,
-                currentUserId,
-                "동아리 멤버만 부원 명단을 조회할 수 있습니다."
-        );
 
         List<ClubMember> clubMembers = clubMemberRepository.findByClubIdAndDeletedAtIsNull(clubId);
 

--- a/src/main/java/com/jandi/band_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/band_backend/config/SecurityConfig.java
@@ -47,10 +47,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/**",
                                 "/health",
-                                "/api/clubs",            // 동아리 목록 조회만 공개
-                                "/api/clubs/*/photo",    // 갤러리 사진 목록 (공개 사진 포함)
-                                "/api/clubs/*/photo/*",  // 갤러리 사진 상세 (공개 사진 포함)
-                                "/api/clubs/*/calendar", // 캘린더 통합 일정
+                                "/api/clubs/**",
                                 "/api/images/**",
                                 "/api/promos",           // 공연 홍보 목록 조회
                                 "/api/promos/{promoId}", // 공연 홍보 상세 조회

--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -41,10 +41,8 @@ public class PollController {
     @GetMapping("/clubs/{clubId}")
     public ResponseEntity<CommonRespDTO<PagedRespDTO<PollRespDTO>>> getPollList(
             @PathVariable Integer clubId,
-            @PageableDefault(size = 5) Pageable pageable,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Integer currentUserId = userDetails.getUserId();
-        Page<PollRespDTO> polls = pollService.getPollsByClub(clubId, currentUserId, pageable);
+            @PageableDefault(size = 5) Pageable pageable) {
+        Page<PollRespDTO> polls = pollService.getPollsByClub(clubId, pageable);
         return ResponseEntity.ok(CommonRespDTO.success("투표 목록을 조회했습니다.", PagedRespDTO.from(polls)));
     }
 
@@ -53,7 +51,7 @@ public class PollController {
     public ResponseEntity<CommonRespDTO<PollDetailRespDTO>> getPollDetail(
             @PathVariable Integer pollId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Integer currentUserId = userDetails.getUserId();
+        Integer currentUserId = userDetails != null ? userDetails.getUserId() : null;
         PollDetailRespDTO responseDto = pollService.getPollDetail(pollId, currentUserId);
         return ResponseEntity.ok(CommonRespDTO.success("투표 상세 정보를 조회했습니다.", responseDto));
     }
@@ -76,7 +74,7 @@ public class PollController {
             @RequestParam(defaultValue = "LIKE") String sortBy, // LIKE, DISLIKE, SCORE
             @RequestParam(defaultValue = "desc") String order, // asc, desc
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Integer currentUserId = userDetails.getUserId();
+        Integer currentUserId = userDetails != null ? userDetails.getUserId() : null;
         List<PollSongResultRespDTO> songs = pollService.getPollSongs(pollId, sortBy, order, currentUserId);
         return ResponseEntity.ok(CommonRespDTO.success("투표 곡 목록을 조회했습니다.", songs));
     }

--- a/src/main/java/com/jandi/band_backend/poll/service/PollService.java
+++ b/src/main/java/com/jandi/band_backend/poll/service/PollService.java
@@ -4,7 +4,6 @@ import com.jandi.band_backend.club.entity.Club;
 import com.jandi.band_backend.global.exception.*;
 import com.jandi.band_backend.global.util.EntityValidationUtil;
 import com.jandi.band_backend.global.util.UserValidationUtil;
-import com.jandi.band_backend.global.util.PermissionValidationUtil;
 import com.jandi.band_backend.poll.dto.*;
 import com.jandi.band_backend.poll.entity.Poll;
 import com.jandi.band_backend.poll.entity.PollSong;
@@ -35,7 +34,6 @@ public class PollService {
     private final VoteRepository voteRepository;
     private final EntityValidationUtil entityValidationUtil;
     private final UserValidationUtil userValidationUtil;
-    private final PermissionValidationUtil permissionValidationUtil;
 
     @Transactional
     public PollRespDTO createPoll(PollReqDTO requestDto, Integer currentUserId) {
@@ -56,14 +54,8 @@ public class PollService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PollRespDTO> getPollsByClub(Integer clubId, Integer currentUserId, Pageable pageable) {
+    public Page<PollRespDTO> getPollsByClub(Integer clubId, Pageable pageable) {
         Club club = entityValidationUtil.validateClubExists(clubId);
-
-        permissionValidationUtil.validateClubMemberAccess(
-                clubId,
-                currentUserId,
-                "동아리 멤버만 투표 목록을 조회할 수 있습니다."
-        );
 
         Page<Poll> polls = pollRepository.findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(club, pageable);
 
@@ -73,14 +65,6 @@ public class PollService {
     @Transactional(readOnly = true)
     public PollDetailRespDTO getPollDetail(Integer pollId, Integer currentUserId) {
         Poll poll = entityValidationUtil.validatePollExists(pollId);
-
-        if (poll.getClub() != null) {
-            permissionValidationUtil.validateClubMemberAccess(
-                    poll.getClub().getId(),
-                    currentUserId,
-                    "동아리 멤버만 투표 상세 정보를 조회할 수 있습니다."
-            );
-        }
 
         List<PollSong> pollSongs = pollSongRepository.findAllByPollAndDeletedAtIsNullOrderByCreatedAtDesc(poll);
 
@@ -94,14 +78,6 @@ public class PollService {
     @Transactional(readOnly = true)
     public List<PollSongResultRespDTO> getPollSongs(Integer pollId, String sortBy, String order, Integer currentUserId) {
         Poll poll = entityValidationUtil.validatePollExists(pollId);
-
-        if (poll.getClub() != null) {
-            permissionValidationUtil.validateClubMemberAccess(
-                    poll.getClub().getId(),
-                    currentUserId,
-                    "동아리 멤버만 투표 결과를 조회할 수 있습니다."
-            );
-        }
 
         List<PollSong> pollSongs = pollSongRepository.findAllByPollAndDeletedAtIsNullOrderByCreatedAtDesc(poll);
 

--- a/src/main/java/com/jandi/band_backend/team/service/TeamService.java
+++ b/src/main/java/com/jandi/band_backend/team/service/TeamService.java
@@ -73,12 +73,6 @@ public class TeamService {
     public Page<TeamRespDTO> getTeamsByClub(Integer clubId, Pageable pageable, Integer currentUserId) {
         Club club = entityValidationUtil.validateClubExists(clubId);
 
-        permissionValidationUtil.validateClubMemberAccess(
-                clubId,
-                currentUserId,
-                "동아리 멤버만 팀 목록을 조회할 수 있습니다."
-        );
-
         Page<Team> teams = teamRepository.findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(club, pageable);
 
         return teams.map(team -> {

--- a/src/test/java/com/jandi/band_backend/poll/service/PollQueryServiceTest.java
+++ b/src/test/java/com/jandi/band_backend/poll/service/PollQueryServiceTest.java
@@ -4,8 +4,6 @@ import com.jandi.band_backend.club.entity.Club;
 import com.jandi.band_backend.global.exception.ClubNotFoundException;
 import com.jandi.band_backend.global.exception.PollNotFoundException;
 import com.jandi.band_backend.global.util.EntityValidationUtil;
-import com.jandi.band_backend.global.util.UserValidationUtil;
-import com.jandi.band_backend.global.util.PermissionValidationUtil;
 import com.jandi.band_backend.poll.dto.PollDetailRespDTO;
 import com.jandi.band_backend.poll.dto.PollRespDTO;
 import com.jandi.band_backend.poll.entity.Poll;
@@ -53,12 +51,6 @@ class PollQueryServiceTest {
 
     @Mock
     private EntityValidationUtil entityValidationUtil;
-
-    @Mock
-    private UserValidationUtil userValidationUtil;
-
-    @Mock
-    private PermissionValidationUtil permissionValidationUtil;
 
     private Club testClub;
     private Users testUser;
@@ -114,7 +106,7 @@ class PollQueryServiceTest {
                 .thenReturn(pollPage);
 
         // When
-        Page<PollRespDTO> result = pollService.getPollsByClub(1, 1, pageable);
+        Page<PollRespDTO> result = pollService.getPollsByClub(1, pageable);
 
         // Then
         assertNotNull(result);
@@ -142,7 +134,7 @@ class PollQueryServiceTest {
 
         // When & Then
         assertThrows(ClubNotFoundException.class,
-                () -> pollService.getPollsByClub(999, 1, pageable));
+                () -> pollService.getPollsByClub(999, pageable));
 
         verify(entityValidationUtil).validateClubExists(999);
         verify(pollRepository, never()).findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(any(), any());
@@ -159,7 +151,7 @@ class PollQueryServiceTest {
                 .thenReturn(emptyPage);
 
         // When
-        Page<PollRespDTO> result = pollService.getPollsByClub(1, 1, pageable);
+        Page<PollRespDTO> result = pollService.getPollsByClub(1, pageable);
 
         // Then
         assertNotNull(result);
@@ -332,7 +324,7 @@ class PollQueryServiceTest {
 
         // When & Then
         assertThrows(RuntimeException.class,
-                () -> pollService.getPollsByClub(1, 1, pageable));
+                () -> pollService.getPollsByClub(1, pageable));
 
         verify(entityValidationUtil).validateClubExists(1);
         verify(pollRepository).findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(testClub, pageable);


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 권한 관련 변경사항들을 되돌립니다 (커밋 범위: 40b6a72 ~ e5790da)
- 동아리 API 접근 권한 검증 로직 원복
- SecurityConfig의 접근 제한 설정 원복

## **✅ 변경 사항**

### 되돌린 커밋 목록:
- `e5790da`: docs: API 문서에 권한 요구사항 추가
- `1995dc0`: fix: SecurityConfig에서 동아리 관련 API 접근 제한
- `3f4e5b7`: feat: Club API 멤버 정보 접근 권한 강화
- `40b6a72`: feat: Poll API에 동아리 멤버 권한 검증 추가

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 권한 관련 변경사항들을 이전 상태로 롤백합니다.
- 단일 revert 커밋으로 4개의 관련 커밋을 한 번에 되돌렸습니다.