### PR TITLE
feat: 일회용 투표로 투표 가능하도록 수정

### DIFF
--- a/src/main/java/com/jandi/band_backend/invite/controller/InviteController.java
+++ b/src/main/java/com/jandi/band_backend/invite/controller/InviteController.java
@@ -41,4 +41,15 @@ public class InviteController {
         InviteLinkRespDTO inviteLinkRespDTO = inviteService.generateInviteTeamLink(teamId, userId);
         return CommonRespDTO.success("팀 초대 링크 생성 성공", inviteLinkRespDTO);
     }
+
+    @Operation(summary = "투표 초대 링크 생성")
+    @PostMapping("/polls/{pollId}")
+    public CommonRespDTO<InviteLinkRespDTO> invitePoll(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("pollId") Integer pollId
+    ) {
+        Integer userId = userDetails.getUserId();
+        InviteLinkRespDTO inviteLinkRespDTO = inviteService.generateInvitePollLink(pollId, userId);
+        return CommonRespDTO.success("투표 초대 링크 생성 성공", inviteLinkRespDTO);
+    }
 }

--- a/src/main/java/com/jandi/band_backend/invite/redis/InviteType.java
+++ b/src/main/java/com/jandi/band_backend/invite/redis/InviteType.java
@@ -1,5 +1,5 @@
 package com.jandi.band_backend.invite.redis;
 
 public enum InviteType {
-    CLUB, TEAM
+    CLUB, TEAM, POLL
 }

--- a/src/main/java/com/jandi/band_backend/invite/service/InviteService.java
+++ b/src/main/java/com/jandi/band_backend/invite/service/InviteService.java
@@ -43,6 +43,18 @@ public class InviteService {
         return new InviteLinkRespDTO(code);
     }
 
+    @Transactional
+    public InviteLinkRespDTO generateInvitePollLink(Integer pollId, Integer userId) {
+        Integer pollsClubId = inviteUtilService.getPollsClubId(pollId);
+        if(!inviteUtilService.isMemberOfClub(pollsClubId, userId)) {
+            throw new InvalidAccessException("초대 권한이 없습니다");
+        }
+
+        String code = generateRandomCode();
+        inviteCodeService.saveCode(InviteType.POLL, pollId, code);
+        return new InviteLinkRespDTO(code);
+    }
+
     private String generateRandomCode() {
         return RANDOM.ints('0', 'z' + 1)
                 .filter(i -> Character.isAlphabetic(i) || Character.isDigit(i))

--- a/src/main/java/com/jandi/band_backend/invite/service/InviteUtilService.java
+++ b/src/main/java/com/jandi/band_backend/invite/service/InviteUtilService.java
@@ -7,6 +7,8 @@ import com.jandi.band_backend.club.repository.ClubRepository;
 import com.jandi.band_backend.global.exception.ClubNotFoundException;
 import com.jandi.band_backend.global.exception.TeamNotFoundException;
 import com.jandi.band_backend.invite.redis.InviteType;
+import com.jandi.band_backend.poll.entity.Poll;
+import com.jandi.band_backend.poll.repository.PollRepository;
 import com.jandi.band_backend.team.entity.Team;
 import com.jandi.band_backend.team.entity.TeamMember;
 import com.jandi.band_backend.team.repository.TeamMemberRepository;
@@ -23,22 +25,23 @@ public class InviteUtilService {
     private final ClubMemberRepository clubMemberRepository;
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final PollRepository pollRepository;
 
     /// 동아리 관련
     // 동아리 존재 확인
-    protected void isExistClub(Integer clubId) {
+    public void isExistClub(Integer clubId) {
         clubRepository.findByIdAndDeletedAtIsNull(clubId)
                 .orElseThrow(() -> new ClubNotFoundException("동아리가 존재하지 않습니다"));
     }
 
     // 동아리 부원인지 확인
-    protected boolean isMemberOfClub(Integer clubId, Integer userId) {
+    public boolean isMemberOfClub(Integer clubId, Integer userId) {
         Optional<ClubMember> Optional = clubMemberRepository.findByClubIdAndUserIdAndDeletedAtIsNull(clubId, userId);
         return Optional.isPresent();
     }
 
     // key에서 동아리 객체 반환
-    protected Club getClub(String keyId) {
+    public Club getClub(String keyId) {
         Integer clubId = getOriginalId(keyId, InviteType.CLUB);
         return clubRepository.findByIdAndDeletedAtIsNull(clubId)
                 .orElseThrow(() -> new ClubNotFoundException("동아리가 존재하지 않습니다"));
@@ -62,6 +65,21 @@ public class InviteUtilService {
         Integer teamId = getOriginalId(keyId, InviteType.TEAM);
         return teamRepository.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() -> new TeamNotFoundException("팀이 존재하지 않습니다"));
+    }
+
+    /// 투표 관련
+    // 투표의 동아리 소재지 찾기
+    public Integer getPollsClubId(Integer pollId) {
+        Poll poll = pollRepository.findByIdAndDeletedAtIsNull(pollId)
+                .orElseThrow(() -> new TeamNotFoundException("투표가 존재하지 않습니다"));
+        return poll.getClub().getId();
+    }
+
+    // key에서 동아리 객체 반환
+    public Poll getPoll(String keyId) {
+        Integer pollId = getOriginalId(keyId, InviteType.POLL);
+        return pollRepository.findByIdAndDeletedAtIsNull(pollId)
+                .orElseThrow(() -> new TeamNotFoundException("투표가 존재하지 않습니다"));
     }
 
     /// 기타

--- a/src/main/java/com/jandi/band_backend/invite/service/JoinService.java
+++ b/src/main/java/com/jandi/band_backend/invite/service/JoinService.java
@@ -8,6 +8,7 @@ import com.jandi.band_backend.global.exception.InvalidAccessException;
 import com.jandi.band_backend.global.exception.UserNotFoundException;
 import com.jandi.band_backend.invite.dto.JoinRespDTO;
 import com.jandi.band_backend.invite.redis.InviteCodeService;
+import com.jandi.band_backend.poll.entity.Poll;
 import com.jandi.band_backend.team.entity.Team;
 import com.jandi.band_backend.team.entity.TeamMember;
 import com.jandi.band_backend.team.repository.TeamMemberRepository;
@@ -62,6 +63,15 @@ public class JoinService {
         }
         createNewTeamMember(user, team);
         return new JoinRespDTO(club.getId(), team.getId());
+    }
+
+    public void verifyPollCode(String code, Integer pollId) {
+        String keyId = inviteCodeService.getKeyId(code);
+        Poll poll = inviteUtilService.getPoll(keyId);
+
+        if(!poll.getId().equals(pollId)) {
+            throw new InvalidAccessException("투표 권한이 없습니다: 발급된 코드와 투표 id가 다릅니다");
+        }
     }
 
     private void createNewClubMember(Users user, Club club) {

--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -4,6 +4,7 @@ import com.jandi.band_backend.global.dto.CommonRespDTO;
 import com.jandi.band_backend.global.dto.PagedRespDTO;
 import com.jandi.band_backend.global.exception.InvalidAccessException;
 import com.jandi.band_backend.invite.dto.JoinRespDTO;
+import com.jandi.band_backend.invite.redis.InviteCodeService;
 import com.jandi.band_backend.invite.service.InviteUtilService;
 import com.jandi.band_backend.invite.service.JoinService;
 import com.jandi.band_backend.poll.dto.*;
@@ -32,6 +33,7 @@ public class PollController {
     private final PollService pollService;
     private final JoinService joinService;
     private final InviteUtilService inviteUtilService;
+    private final InviteCodeService inviteCodeService;
 
     @Operation(summary = "투표 생성")
     @PostMapping
@@ -97,6 +99,7 @@ public class PollController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         if (code != null) {
             joinService.verifyPollCode(code, pollId);
+            inviteCodeService.deleteRecord(code);
         }
         else {
             Integer userId = userDetails.getUserId();

--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -97,7 +97,7 @@ public class PollController {
             @PathVariable String emoji,
             @RequestParam(required = false) String code,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (code != null) {
+        if (code != null) { // 외부인: 코드 검증 필요
             joinService.verifyPollCode(code, pollId);
             inviteCodeService.deleteRecord(code);
         }
@@ -105,7 +105,7 @@ public class PollController {
             Integer userId = userDetails.getUserId();
             Integer pollsClubId = inviteUtilService.getPollsClubId(pollId);
             if(!inviteUtilService.isMemberOfClub(pollsClubId, userId))
-                throw new InvalidAccessException("투표 권한이 없습니다: 동아리원이 아닙니다");
+                throw new InvalidAccessException("팀원만 투표할 수 있습니다");
         }
         PollSongRespDTO responseDto = pollService.setVoteForSong(pollId, songId, emoji, userDetails.getUserId());
         return ResponseEntity.ok(CommonRespDTO.success("투표가 설정되었습니다.", responseDto));

--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -95,14 +95,14 @@ public class PollController {
             @PathVariable String emoji,
             @RequestParam(required = false) String code,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (code != null) { // 외부인: 코드 검증 필요
+        if (code != null) {
             joinService.verifyPollCode(code, pollId);
         }
         else {
             Integer userId = userDetails.getUserId();
             Integer pollsClubId = inviteUtilService.getPollsClubId(pollId);
             if(!inviteUtilService.isMemberOfClub(pollsClubId, userId))
-                throw new InvalidAccessException("팀원만 투표할 수 있습니다");
+                throw new InvalidAccessException("투표 권한이 없습니다: 동아리원이 아닙니다");
         }
         PollSongRespDTO responseDto = pollService.setVoteForSong(pollId, songId, emoji, userDetails.getUserId());
         return ResponseEntity.ok(CommonRespDTO.success("투표가 설정되었습니다.", responseDto));


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #이슈번호

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 비회원: 회원가입 안된사람 → 투표 불가, 코드 있어도 불가
- 일반회원: 회원가입 완료, 동아리원은 아님 → 투표 불가
    - 단, 일반회원 중 일회용 코드가 있다면(=투표 링크로 들어올 때) 투표 가능
- 동아리원: 회원가입 완료, 동아리원임 → 투표 가능, 코드 있던없던 가능!

## **✅ 변경 사항**

- pollcontroller에서 따로 권한을 체크하지 않아 로그인만 되어있다면 누구든 투표 가능했지만, 이번 작업으로 유효한 코드를 가지고 있거나 동아리원일 때만 투표가능하게 막아두었습니다

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 리뷰 시 참고하거나 봐줬으면 하는 부분이 있다면 작성해주세요.
