### PR TITLE
fix: 투표 목록 조회, 투표 상세 조회의 권한 변경

### DIFF
--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -49,8 +49,7 @@ public class PollController {
             @PathVariable Integer clubId,
             @PageableDefault(size = 5) Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Integer currentUserId = userDetails.getUserId();
-        Page<PollRespDTO> polls = pollService.getPollsByClub(clubId, currentUserId, pageable);
+        Page<PollRespDTO> polls = pollService.getPollsByClub(clubId, pageable);
         return ResponseEntity.ok(CommonRespDTO.success("투표 목록을 조회했습니다.", PagedRespDTO.from(polls)));
     }
 
@@ -80,10 +79,9 @@ public class PollController {
     public ResponseEntity<CommonRespDTO<List<PollSongResultRespDTO>>> getPollSongs(
             @PathVariable Integer pollId,
             @RequestParam(defaultValue = "LIKE") String sortBy, // LIKE, DISLIKE, SCORE
-            @RequestParam(defaultValue = "desc") String order, // asc, desc
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Integer currentUserId = userDetails.getUserId();
-        List<PollSongResultRespDTO> songs = pollService.getPollSongs(pollId, sortBy, order, currentUserId);
+            @RequestParam(defaultValue = "desc") String order // asc, desc
+            ) {
+        List<PollSongResultRespDTO> songs = pollService.getPollSongs(pollId, sortBy, order);
         return ResponseEntity.ok(CommonRespDTO.success("투표 곡 목록을 조회했습니다.", songs));
     }
 

--- a/src/main/java/com/jandi/band_backend/poll/service/PollService.java
+++ b/src/main/java/com/jandi/band_backend/poll/service/PollService.java
@@ -56,15 +56,8 @@ public class PollService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PollRespDTO> getPollsByClub(Integer clubId, Integer currentUserId, Pageable pageable) {
+    public Page<PollRespDTO> getPollsByClub(Integer clubId, Pageable pageable) {
         Club club = entityValidationUtil.validateClubExists(clubId);
-
-        permissionValidationUtil.validateClubMemberAccess(
-                clubId,
-                currentUserId,
-                "동아리 멤버만 투표 목록을 조회할 수 있습니다."
-        );
-
         Page<Poll> polls = pollRepository.findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(club, pageable);
 
         return polls.map(this::convertToPollRespDTO);
@@ -73,15 +66,6 @@ public class PollService {
     @Transactional(readOnly = true)
     public PollDetailRespDTO getPollDetail(Integer pollId, Integer currentUserId) {
         Poll poll = entityValidationUtil.validatePollExists(pollId);
-
-        if (poll.getClub() != null) {
-            permissionValidationUtil.validateClubMemberAccess(
-                    poll.getClub().getId(),
-                    currentUserId,
-                    "동아리 멤버만 투표 상세 정보를 조회할 수 있습니다."
-            );
-        }
-
         List<PollSong> pollSongs = pollSongRepository.findAllByPollAndDeletedAtIsNullOrderByCreatedAtDesc(poll);
 
         List<PollSongRespDTO> songResponseDtos = pollSongs.stream()
@@ -92,17 +76,8 @@ public class PollService {
     }
 
     @Transactional(readOnly = true)
-    public List<PollSongResultRespDTO> getPollSongs(Integer pollId, String sortBy, String order, Integer currentUserId) {
+    public List<PollSongResultRespDTO> getPollSongs(Integer pollId, String sortBy, String order) {
         Poll poll = entityValidationUtil.validatePollExists(pollId);
-
-        if (poll.getClub() != null) {
-            permissionValidationUtil.validateClubMemberAccess(
-                    poll.getClub().getId(),
-                    currentUserId,
-                    "동아리 멤버만 투표 결과를 조회할 수 있습니다."
-            );
-        }
-
         List<PollSong> pollSongs = pollSongRepository.findAllByPollAndDeletedAtIsNullOrderByCreatedAtDesc(poll);
 
         List<PollSongResultRespDTO> songResultDtos = pollSongs.stream()

--- a/src/test/java/com/jandi/band_backend/poll/service/PollQueryServiceTest.java
+++ b/src/test/java/com/jandi/band_backend/poll/service/PollQueryServiceTest.java
@@ -114,7 +114,7 @@ class PollQueryServiceTest {
                 .thenReturn(pollPage);
 
         // When
-        Page<PollRespDTO> result = pollService.getPollsByClub(1, 1, pageable);
+        Page<PollRespDTO> result = pollService.getPollsByClub(1, pageable);
 
         // Then
         assertNotNull(result);
@@ -142,7 +142,7 @@ class PollQueryServiceTest {
 
         // When & Then
         assertThrows(ClubNotFoundException.class,
-                () -> pollService.getPollsByClub(999, 1, pageable));
+                () -> pollService.getPollsByClub(999, pageable));
 
         verify(entityValidationUtil).validateClubExists(999);
         verify(pollRepository, never()).findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(any(), any());
@@ -159,7 +159,7 @@ class PollQueryServiceTest {
                 .thenReturn(emptyPage);
 
         // When
-        Page<PollRespDTO> result = pollService.getPollsByClub(1, 1, pageable);
+        Page<PollRespDTO> result = pollService.getPollsByClub(1, pageable);
 
         // Then
         assertNotNull(result);
@@ -332,7 +332,7 @@ class PollQueryServiceTest {
 
         // When & Then
         assertThrows(RuntimeException.class,
-                () -> pollService.getPollsByClub(1, 1, pageable));
+                () -> pollService.getPollsByClub(1, pageable));
 
         verify(entityValidationUtil).validateClubExists(1);
         verify(pollRepository).findAllByClubAndDeletedAtIsNullOrderByCreatedAtDesc(testClub, pageable);

--- a/src/test/java/com/jandi/band_backend/poll/service/PollSortingServiceTest.java
+++ b/src/test/java/com/jandi/band_backend/poll/service/PollSortingServiceTest.java
@@ -116,7 +116,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc");
 
         // Then
         assertNotNull(result);
@@ -145,7 +145,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "asc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "asc");
 
         // Then
         assertNotNull(result);
@@ -171,7 +171,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "DISLIKE", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "DISLIKE", "desc");
 
         // Then
         assertNotNull(result);
@@ -197,7 +197,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "SCORE", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "SCORE", "desc");
 
         // Then
         assertNotNull(result);
@@ -226,7 +226,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "SCORE", "asc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "SCORE", "asc");
 
         // Then
         assertNotNull(result);
@@ -248,7 +248,7 @@ class PollSortingServiceTest {
 
         // When & Then
         assertThrows(BadRequestException.class,
-                () -> pollService.getPollSongs(1, "INVALID", "desc", 1));
+                () -> pollService.getPollSongs(1, "INVALID", "desc"));
 
         verify(entityValidationUtil).validatePollExists(1);
         verify(pollSongRepository).findAllByPollAndDeletedAtIsNullOrderByCreatedAtDesc(testPoll);
@@ -264,7 +264,7 @@ class PollSortingServiceTest {
 
         // When & Then
         assertThrows(BadRequestException.class,
-                () -> pollService.getPollSongs(1, null, "desc", 1));
+                () -> pollService.getPollSongs(1, null, "desc"));
 
         verify(entityValidationUtil).validatePollExists(1);
         verify(pollSongRepository).findAllByPollAndDeletedAtIsNullOrderByCreatedAtDesc(testPoll);
@@ -279,7 +279,7 @@ class PollSortingServiceTest {
                 .thenReturn(Collections.emptyList());
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc");
 
         // Then
         assertNotNull(result);
@@ -301,7 +301,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(zeroVoteSong1, zeroVoteSong2));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc");
 
         // Then
         assertNotNull(result);
@@ -327,7 +327,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(tiedSong1, tiedSong2));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "desc");
 
         // Then
         assertNotNull(result);
@@ -353,7 +353,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(negativeSong1, negativeSong2));
 
         // When
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "SCORE", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "SCORE", "desc");
 
         // Then
         assertNotNull(result);
@@ -373,7 +373,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When - 소문자로 정렬 기준 전송
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "like", "desc", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "like", "desc");
 
         // Then
         assertNotNull(result);
@@ -393,7 +393,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When - 대문자로 정렬 순서 전송
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "ASC", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "ASC");
 
         // Then
         assertNotNull(result);
@@ -413,7 +413,7 @@ class PollSortingServiceTest {
                 .thenReturn(Arrays.asList(song1, song2, song3));
 
         // When - 정렬 순서를 지정하지 않거나 잘못된 값 전송 (기본값은 desc)
-        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "invalid_order", 1);
+        List<PollSongResultRespDTO> result = pollService.getPollSongs(1, "LIKE", "invalid_order");
 
         // Then
         assertNotNull(result);


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #이슈번호

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **✅ 변경 사항**

- 동아리 아닌 사람도 투표 목록 조회가능하도록 수정
- 동아리 아닌 사람도 투표 상세 조회가능하도록 수정

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 건영님 코드 보니 투표 목록 조회, 상세 조회를 막아두셔서 풀었습니당
- 건영님 작업한게 master에 합쳐지고 난 뒤에 제가 투표 일회용코드 작업을 했더라구요
