### PR TITLE
fix: 토큰이 헤더로 전송되도록 수정하고, 토큰 블랙리스트 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,3 @@
 <img width="2000" height="1125" alt="Image" src="https://github.com/kyj0503/image/blob/main/JandiGoorm/RhythMeet/RhythMeet%20(31).png" />
 <img width="2000" height="1125" alt="Image" src="https://github.com/kyj0503/image/blob/main/JandiGoorm/RhythMeet/RhythMeet%20(32).png" />
 <img width="2000" height="1125" alt="Image" src="https://github.com/kyj0503/image/blob/main/JandiGoorm/RhythMeet/RhythMeet%20(33).png" />
-
-test

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import com.jandi.band_backend.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,14 +29,17 @@ public class AuthController {
 
     @Operation(summary = "카카오 로그인")
     @GetMapping("/login")
-    public CommonRespDTO<TokenRespDTO> kakaoLogin(
+    public ResponseEntity<CommonRespDTO<Object>> kakaoLogin(
             @RequestParam String code
     ){
         KakaoTokenRespDTO kakaoToken = kaKaoTokenService.getKakaoToken(code);
         KakaoUserInfoDTO kakaoUserInfo = kakaoUserService.getKakaoUserInfo(kakaoToken.getAccessToken());
 
         TokenRespDTO tokens = authService.login(kakaoUserInfo);
-        return CommonRespDTO.success("로그인 성공", tokens);
+        return ResponseEntity.ok()
+                .header("accessToken", tokens.getAccessToken())
+                .header("refreshToken", tokens.getRefreshToken())
+                .body(CommonRespDTO.success("로그인 성공"));
     }
 
     @Operation(summary = "로그아웃")

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.jandi.band_backend.auth.dto.RefreshReqDTO;
 import com.jandi.band_backend.auth.dto.SignUpReqDTO;
 import com.jandi.band_backend.auth.dto.kakao.KakaoTokenRespDTO;
 import com.jandi.band_backend.auth.dto.kakao.KakaoUserInfoDTO;
-import com.jandi.band_backend.auth.redis.TokenBlacklistService;
 import com.jandi.band_backend.auth.service.kakao.KaKaoTokenService;
 import com.jandi.band_backend.auth.service.kakao.KakaoUserService;
 import com.jandi.band_backend.global.dto.CommonRespDTO;

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.jandi.band_backend.auth.controller;
 
+import com.jandi.band_backend.auth.dto.LoginRespDTO;
 import com.jandi.band_backend.auth.dto.TokenRespDTO;
 import com.jandi.band_backend.auth.dto.RefreshReqDTO;
 import com.jandi.band_backend.auth.dto.SignUpReqDTO;
@@ -36,13 +37,13 @@ public class AuthController {
         KakaoTokenRespDTO kakaoToken = kaKaoTokenService.getKakaoToken(code);
         KakaoUserInfoDTO kakaoUserInfo = kakaoUserService.getKakaoUserInfo(kakaoToken.getAccessToken());
 
-        TokenRespDTO tokens = authService.login(kakaoUserInfo);
+        LoginRespDTO loginRespDTO = authService.login(kakaoUserInfo);
         return ResponseEntity.ok()
                 .header(HttpHeaders.CACHE_CONTROL, "no-store")
                 .header("Pragma", "no-cache")
-                .header("accessToken", tokens.getAccessToken())
-                .header("refreshToken", tokens.getRefreshToken())
-                .body(CommonRespDTO.success("로그인 성공"));
+                .header("accessToken", loginRespDTO.getAccessToken())
+                .header("refreshToken", loginRespDTO.getRefreshToken())
+                .body(CommonRespDTO.success("로그인 성공", loginRespDTO));
     }
 
     @Operation(summary = "로그아웃")

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -43,8 +43,8 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.CACHE_CONTROL, "no-store")
                 .header("Pragma", "no-cache")
-                .header("accessToken", loginRespDTO.getAccessToken())
-                .header("refreshToken", loginRespDTO.getRefreshToken())
+                .header("AccessToken", loginRespDTO.getAccessToken())
+                .header("RefreshToken", loginRespDTO.getRefreshToken())
                 .body(CommonRespDTO.success("로그인 성공", loginRespDTO));
     }
 
@@ -94,8 +94,8 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.CACHE_CONTROL, "no-store")
                 .header("Pragma", "no-cache")
-                .header("accessToken", tokens.getAccessToken())
-                .header("refreshToken", tokens.getRefreshToken())
+                .header("AccessToken", tokens.getAccessToken())
+                .header("RefreshToken", tokens.getRefreshToken())
                 .body(CommonRespDTO.success("토큰 재발급 성공"));
     }
 }

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import com.jandi.band_backend.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +39,8 @@ public class AuthController {
 
         TokenRespDTO tokens = authService.login(kakaoUserInfo);
         return ResponseEntity.ok()
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .header("Pragma", "no-cache")
                 .header("accessToken", tokens.getAccessToken())
                 .header("refreshToken", tokens.getRefreshToken())
                 .body(CommonRespDTO.success("로그인 성공"));
@@ -83,6 +86,8 @@ public class AuthController {
         String refreshToken = refreshReqDTO.getRefreshToken();
         TokenRespDTO tokens = authService.refresh(refreshToken);
         return ResponseEntity.ok()
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .header("Pragma", "no-cache")
                 .header("accessToken", tokens.getAccessToken())
                 .header("refreshToken", tokens.getRefreshToken())
                 .body(CommonRespDTO.success("토큰 재발급 성공"));

--- a/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/jandi/band_backend/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import com.jandi.band_backend.user.dto.UserInfoDTO;
 import com.jandi.band_backend.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,7 @@ public class AuthController {
     private final KaKaoTokenService kaKaoTokenService;
     private final KakaoUserService kakaoUserService;
 
+    @Transactional
     @Operation(summary = "카카오 로그인")
     @GetMapping("/login")
     public ResponseEntity<CommonRespDTO<Object>> kakaoLogin(
@@ -46,6 +48,7 @@ public class AuthController {
                 .body(CommonRespDTO.success("로그인 성공", loginRespDTO));
     }
 
+    @Transactional
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public CommonRespDTO<String> logout(
@@ -57,6 +60,7 @@ public class AuthController {
         return CommonRespDTO.success("로그아웃 완료");
     }
 
+    @Transactional
     @Operation(summary = "회원가입")
     @PostMapping("/signup")
     public CommonRespDTO<UserInfoDTO> signUp(
@@ -68,6 +72,7 @@ public class AuthController {
         return CommonRespDTO.success("회원가입 성공", userInfo);
     }
 
+    @Transactional
     @Operation(summary = "회원탈퇴")
     @PostMapping("/cancel")
     public CommonRespDTO<UserInfoDTO> cancel(
@@ -78,6 +83,7 @@ public class AuthController {
         return CommonRespDTO.success("회원탈퇴 성공");
     }
 
+    @Transactional
     @Operation(summary = "토큰 재발급")
     @PostMapping("/refresh")
     public ResponseEntity<CommonRespDTO<TokenRespDTO>> refresh(

--- a/src/main/java/com/jandi/band_backend/auth/dto/TokenRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/auth/dto/TokenRespDTO.java
@@ -1,5 +1,6 @@
 package com.jandi.band_backend.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TokenRespDTO {
+    @JsonIgnore
     private String accessToken;
+    @JsonIgnore
     private String refreshToken;
 }

--- a/src/main/java/com/jandi/band_backend/auth/dto/TokenRespDTO.java
+++ b/src/main/java/com/jandi/band_backend/auth/dto/TokenRespDTO.java
@@ -9,6 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TokenRespDTO {
     private String accessToken;
-    
     private String refreshToken;
 }

--- a/src/main/java/com/jandi/band_backend/auth/redis/TokenBlacklistService.java
+++ b/src/main/java/com/jandi/band_backend/auth/redis/TokenBlacklistService.java
@@ -3,7 +3,6 @@ package com.jandi.band_backend.auth.redis;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;

--- a/src/main/java/com/jandi/band_backend/auth/redis/TokenBlacklistService.java
+++ b/src/main/java/com/jandi/band_backend/auth/redis/TokenBlacklistService.java
@@ -1,0 +1,31 @@
+package com.jandi.band_backend.auth.redis;
+
+import com.jandi.band_backend.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+    private final StringRedisTemplate redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public void saveToken(String refreshToken) {
+        // key: blacklist:refreshToken:{hash} 형태 -> 원문 노출을 막고 조회 규칙을 명확히 하기 위함
+        String key = "bl:rt:" + sha256Hex(refreshToken);
+
+        // 만료 임박/시계차로 음수가 나오는 것을 방지하기 위해 최소 1초로 설정
+        long remainSecond = Math.max(1, jwtTokenProvider.getRemainMillSecond(refreshToken));
+        redisTemplate.opsForValue().set(key, "1", Duration.ofSeconds(remainSecond));
+    }
+
+    public boolean isTokenBlacklist(String refreshToken) {
+        String key = "bl:rt:" + sha256Hex(refreshToken);
+        return redisTemplate.hasKey(key);
+    }
+}

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -72,7 +72,7 @@ public class AuthService {
 
     /// 로그인
     @Transactional
-    public TokenRespDTO login(KakaoUserInfoDTO kakaoUserInfo) {
+    public LoginRespDTO login(KakaoUserInfoDTO kakaoUserInfo) {
         // DB에서 유저를 찾되, 없다면 임시 회원 가입 진행
         Users user = getOrCreateUser(kakaoUserInfo);
 

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -97,7 +97,6 @@ public class AuthService {
 
         // 토큰 블랙리스트
         tokenBlacklistService.saveToken(refreshToken);
-        log.info("KakaoOauthId: {}의 토큰 블랙리스트화 완료, refreshToken={}", user.getKakaoOauthId(), refreshToken);
     }
 
     /// 정식 회원가입

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.jandi.band_backend.auth.service;
 
 import com.jandi.band_backend.auth.dto.*;
 import com.jandi.band_backend.auth.dto.kakao.KakaoUserInfoDTO;
+import com.jandi.band_backend.auth.redis.TokenBlacklistService;
 import com.jandi.band_backend.auth.service.kakao.KakaoUserService;
 import com.jandi.band_backend.club.entity.ClubMember;
 import com.jandi.band_backend.club.repository.ClubMemberRepository;
@@ -47,6 +48,7 @@ public class AuthService {
     private final ClubMemberRepository clubMemberRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenBlacklistService tokenBlacklistService;
     private final KakaoUserService kakaoUserService;
     // 그룹 2
     private final ClubGalPhotoRepository clubGalPhotoRepository;
@@ -88,12 +90,14 @@ public class AuthService {
     }
 
     /// 로그아웃
-    public void logout(Integer userId) {
-        // 멘토링 결과 별도의 블랙리스트 처리는 필요하지 않아 로깅만 하는 것으로 작업
-        // 카카오 토큰은 카카오 리소스 접근용이라 알림톡/메시지 공유에선 쓰이지 않아 굳이 카카오에게 로그아웃을 요청해 강제 만료처리할 필요가 없음
+    public void logout(Integer userId, String refreshToken) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         log.info("KakaoOauthId: {}가 로그아웃 요청", user.getKakaoOauthId());
+
+        // 토큰 블랙리스트
+        tokenBlacklistService.saveToken(refreshToken);
+        log.info("KakaoOauthId: {}의 토큰 블랙리스트화 완료, refreshToken={}", user.getKakaoOauthId(), refreshToken);
     }
 
     /// 정식 회원가입

--- a/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
+++ b/src/main/java/com/jandi/band_backend/auth/service/AuthService.java
@@ -95,8 +95,10 @@ public class AuthService {
                 .orElseThrow(UserNotFoundException::new);
         log.info("KakaoOauthId: {}가 로그아웃 요청", user.getKakaoOauthId());
 
-        // 토큰 블랙리스트
-        tokenBlacklistService.saveToken(refreshToken);
+        // 정상적인 리프레시 토큰이 맞는지 확인 후 토큰 블랙리스트
+        if(jwtTokenProvider.validateToken(refreshToken) && !jwtTokenProvider.isAccessToken(refreshToken)) {
+            tokenBlacklistService.saveToken(refreshToken);
+        }
     }
 
     /// 정식 회원가입

--- a/src/main/java/com/jandi/band_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/band_backend/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                     ));
                     config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
                     config.setAllowedHeaders(List.of("*"));
-                    config.setExposedHeaders(List.of("Authorization"));
+                    config.setExposedHeaders(List.of("Authorization", "AccessToken", "RefreshToken"));
                     config.setAllowCredentials(true);
                     config.setMaxAge(3600L);
                     return config;

--- a/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
@@ -110,11 +110,17 @@ public class JwtTokenProvider {
 
     public boolean validateToken(String token) {
         try {
-            parseClaims(token);
+            // 이미 블랙리스트인 경우
             if(tokenBlacklistService.isTokenBlacklist(token)) {
-                throw new RuntimeException("블랙리스트화된 토큰입니다.");
+                log.debug("잘못된 토큰: 이미 블랙리스트된 토큰입니다");
+                return false;
             }
+
+            parseClaims(token);
             return true;
+        } catch (ExpiredJwtException e) {
+            log.debug("잘못된 토큰: {}", e.getMessage());
+            return false;
         } catch (Exception e) {
             log.error("JWT 토큰 유효성 검사 실패: {}", e.getMessage());
             return false;

--- a/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.time.Instant;
 import java.util.Date;
 
 @Slf4j

--- a/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
@@ -109,19 +109,6 @@ public class JwtTokenProvider {
         }
     }
 
-    public long getRemainMillSecond(String token) {
-        try{
-            Claims claims = parseClaims(token);
-            Date expiration = claims.getExpiration();
-            long remainMillTime = expiration.getTime() - System.currentTimeMillis();
-            log.debug("토큰에서 추출된 만료까지 남은 시간(ms): " + remainMillTime);
-            return expiration.toInstant().getEpochSecond() - Instant.now().getEpochSecond();
-        }catch (JwtException e){
-            log.error("토큰에서 만료까지 남은 시간 추출 실패: " +e.getMessage());
-            throw new InvalidTokenException();
-        }
-    }
-
     public boolean validateToken(String token) {
         try {
             parseClaims(token);

--- a/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jandi/band_backend/security/jwt/JwtTokenProvider.java
@@ -113,7 +113,7 @@ public class JwtTokenProvider {
         try {
             parseClaims(token);
             if(tokenBlacklistService.isTokenBlacklist(token)) {
-                throw new InvalidTokenException();
+                throw new RuntimeException("블랙리스트화된 토큰입니다.");
             }
             return true;
         } catch (Exception e) {


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #이슈번호

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 토큰이 헤더로 전송되도록 수정
- 토큰 블랙리스트 적용
- 로그인 관련 작업 시 트랜잭션 처리

## **✅ 변경 사항**

- 리프레시 토큰은 쿠키에 저장되어 헤더에 넣어지도록 변경 (httpOnly, secure 적용, 모든 경로에서 사용 가능, 14일 후 폐기)
- 액세스 토큰은 바로 헤더에 넣어지도록 수정 (AcessToken에 들어감)
- 위의 두 작업은 로그인&토큰 재발급 시 적용되는 사항임
- 로그아웃 시, 리프레시 토큰을 레디스에 기록하여 토큰 블랙리스트화 (리프레시 토큰의 남은 기간만큼 유지 후 자동 폐기)
- 로그인 시 회원가입 여부도 바디에 넣어 함께 넘겨주도록 수정 (어느순간부터 사라져있길래(?) 다시 추가)
- 로그인, 로그아웃, 회원가입, 회원탈퇴 시 트랜잭션 처리되도록 어노테이션 추가

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 리뷰 시 참고하거나 봐줬으면 하는 부분이 있다면 작성해주세요.
