### PR TITLE
feat: PollSong 삭제 API 추가

### DIFF
--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -75,16 +75,6 @@ public class PollController {
                 .body(CommonRespDTO.success("곡이 성공적으로 투표에 추가되었습니다.", responseDto));
     }
 
-    @Operation(summary = "투표 곡 삭제")
-    @DeleteMapping("/{pollId}/songs/{songId}")
-    public ResponseEntity<CommonRespDTO<Void>> deleteSongFromPoll(
-            @PathVariable Integer pollId,
-            @PathVariable Integer songId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        pollService.deletePollSong(pollId, songId, userDetails.getUserId());
-        return ResponseEntity.ok(CommonRespDTO.success("투표 곡이 성공적으로 삭제되었습니다.", null));
-    }
-
     @Operation(summary = "투표 곡 목록 조회 (정렬)")
     @GetMapping("/{pollId}/songs")
     public ResponseEntity<CommonRespDTO<List<PollSongResultRespDTO>>> getPollSongs(
@@ -94,6 +84,16 @@ public class PollController {
         ) {
         List<PollSongResultRespDTO> songs = pollService.getPollSongs(pollId, sortBy, order);
         return ResponseEntity.ok(CommonRespDTO.success("투표 곡 목록을 조회했습니다.", songs));
+    }
+
+    @Operation(summary = "투표 곡 삭제")
+    @DeleteMapping("/{pollId}/songs/{songId}")
+    public ResponseEntity<CommonRespDTO<Void>> deleteSongFromPoll(
+            @PathVariable Integer pollId,
+            @PathVariable Integer songId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        pollService.deletePollSong(pollId, songId, userDetails.getUserId());
+        return ResponseEntity.ok(CommonRespDTO.success("투표 곡이 성공적으로 삭제되었습니다.", null));
     }
 
     @Operation(summary = "곡에 투표하기")

--- a/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
+++ b/src/main/java/com/jandi/band_backend/poll/controller/PollController.java
@@ -75,6 +75,16 @@ public class PollController {
                 .body(CommonRespDTO.success("곡이 성공적으로 투표에 추가되었습니다.", responseDto));
     }
 
+    @Operation(summary = "투표 곡 삭제")
+    @DeleteMapping("/{pollId}/songs/{songId}")
+    public ResponseEntity<CommonRespDTO<Void>> deleteSongFromPoll(
+            @PathVariable Integer pollId,
+            @PathVariable Integer songId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        pollService.deletePollSong(pollId, songId, userDetails.getUserId());
+        return ResponseEntity.ok(CommonRespDTO.success("투표 곡이 성공적으로 삭제되었습니다.", null));
+    }
+
     @Operation(summary = "투표 곡 목록 조회 (정렬)")
     @GetMapping("/{pollId}/songs")
     public ResponseEntity<CommonRespDTO<List<PollSongResultRespDTO>>> getPollSongs(

--- a/src/test/java/com/jandi/band_backend/poll/controller/PollControllerTest.java
+++ b/src/test/java/com/jandi/band_backend/poll/controller/PollControllerTest.java
@@ -178,6 +178,22 @@ class PollControllerTest {
     }
 
     @Test
+    @DisplayName("투표 곡 삭제 - 정상 케이스")
+    void deleteSongFromPoll_Success() throws Exception {
+        // Given
+        doNothing().when(pollService).deletePollSong(1, 2, 1);
+
+        // When & Then
+        mockMvc.perform(delete("/api/polls/1/songs/2")
+                        .header("Authorization", "Bearer mock-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("투표 곡이 성공적으로 삭제되었습니다."));
+
+        verify(pollService).deletePollSong(1, 2, 1);
+    }
+
+    @Test
     @DisplayName("존재하지 않는 투표 조회")
     void getPollDetail_NotFound() throws Exception {
         // Given

--- a/src/test/java/com/jandi/band_backend/poll/controller/PollControllerUnitTest.java
+++ b/src/test/java/com/jandi/band_backend/poll/controller/PollControllerUnitTest.java
@@ -213,6 +213,21 @@ class PollControllerUnitTest {
     }
 
     @Test
+    @DisplayName("투표 곡 삭제 - 정상 처리")
+    void deleteSongFromPoll_Success() throws Exception {
+        // Given
+        authenticate();
+
+        // When & Then
+        mockMvc.perform(delete("/api/polls/1/songs/2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("투표 곡이 성공적으로 삭제되었습니다."));
+
+        verify(pollService).deletePollSong(1, 2, 1);
+    }
+
+    @Test
     @DisplayName("투표 곡 목록 조회 - 정상 처리")
     void getPollSongs_Success() throws Exception {
         // Given


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- feat: PollSong 삭제 API 추가

## **✅ 변경 사항**

- 곡 제안자 또는 동아리 대표자 권한으로 PollSong 삭제하는 `PollService`에 `deletePollSong` 메서드 도입
- `PollSong` 및 관련 `Vote` 소프트 삭제 적용
- `PollSong` 삭제 시나리오에 대한 테스트 케이스 확장
